### PR TITLE
feat: create GitHub Release as part of CICD

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -119,3 +119,5 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: ${{ needs.release-tag.outputs.release-notes }}
+          prerelease: ${{ needs.prepare-tag-release.outputs.prerelease }}
+          draft: true


### PR DESCRIPTION
## Description
This pull request adds an additional job to the existing CI workflow developed in issue https://github.com/hashgraph/full-stack-testing/issues/36 and enhanced in issue https://github.com/hashgraph/full-stack-testing/issues/107 to create a new release in Github with the release notes already generated in the prior workflow job.

## Related Issues
- closes #109 
- relates to #36 
- relates to #107 