### PR TITLE
fix: root container should run in privilege mode as root user

### DIFF
--- a/charts/hedera-network/templates/network-node-statefulset.yaml
+++ b/charts/hedera-network/templates/network-node-statefulset.yaml
@@ -37,8 +37,10 @@ spec:
       containers:
       - name: root-container
         image: {{ $.Values.infrastructure.docker.images.root }}
-        command: [ "/bin/sh" ]
-        args: [ "-c", "while true; do echo root:heartbeat; sleep 10;done" ]
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          privileged: true
         resources:
           requests:
             cpu: {{ $node.requests.cpu }}


### PR DESCRIPTION
## Description

This pull request changes the following:
- allow root-container to run in privilege mode as root user (user:0, group: 0)
- removes `command` entry

The log below shows that it runs as root user and `systemctl status` command can be run:
```
[root@network-node-1-0 hgcapp]# id
uid=0(root) gid=0(root) groups=0(root)
[root@network-node-1-0 hgcapp]# systemctl status
● network-node-1-0
    State: running
     Jobs: 0 queued
   Failed: 0 units
    Since: Wed 2023-07-05 19:56:01 UTC; 1min 36s ago
   CGroup: /kubelet.slice/kubelet-kubepods.slice/kubelet-kubepods-burstable.slice/kubelet-kubepods-burstable-podf0df8fb8_b09a_4e9a_a1ab_1ac033e1300d.slice/cri-containerd-2baf98cd30c873052abdc4e3264c68279b9cc0
588502ca8f7c782fc17245dfd3.scope
           ├─init.scope
           │ ├─  1 /sbin/init
           │ ├─151 bash
           │ ├─170 systemctl status
           │ └─171 [(pager)]
           └─system.slice
             ├─containerd.service
             │ └─35 /usr/bin/containerd
             ├─docker.service
             │ └─46 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
             ├─systemd-journald.service
             │ └─24 /usr/lib/systemd/systemd-journald
             └─dbus.service
               └─34 /usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
```

### Related Issues

- Closes #142 
