### PR TITLE
fix: Helm chart statefulset has incorrect config for uploader sidecars 

### DIFF
--- a/charts/hedera-network/templates/configmaps.yaml
+++ b/charts/hedera-network/templates/configmaps.yaml
@@ -22,27 +22,6 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: record-stream-uploader-config
-data:
-  DEBUG: "{{ $.Values.mirror.debug }}"
-  REAPER_ENABLE: "{{ $.Values.mirror.reaper.enable }}"
-  REAPER_MIN_KEEP: "{{ $.Values.mirror.reaper.minKeep }}"
-  REAPER_INTERVAL: "{{ $.Values.mirror.reaper.interval }}"
-  REAPER_DEFAULT_BACKOFF: "{{ $.Values.mirror.reaper.defaultBackoff }}"
-  STREAM_FILE_EXTENSION: "rcd"
-  STREAM_SIG_EXTENSION: "rcd_sig"
-  STREAM_EXTENSION: "rcd"
-  S3_ENABLE: "{{ $.Values.mirror.s3.enable }}"
-  GCS_ENABLE: "{{ $.Values.mirror.gcs.enable }}"
-  SIG_REQUIRE: "{{ $.Values.mirror.sig.require }}"
-  SIG_PRIORITIZE: "{{ $.Values.mirror.sig.prioritize }}"
-  SIG_EXTENSION: "rcd_sig"
-  BUCKET_PATH: "{{ $.Values.mirror.recordStream.bucketPath }}"
-  BUCKET_NAME: "{{ $.Values.mirror.recordStream.bucketName }}"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: event-stream-uploader-config
 data:
   DEBUG: "{{ $.Values.mirror.debug }}"
@@ -64,7 +43,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: record-stream-sidecar-config
+  name: record-stream-uploader-config
 data:
   DEBUG: "{{ $.Values.mirror.debug }}"
   REAPER_ENABLE: "{{ $.Values.mirror.reaper.enable }}"
@@ -73,7 +52,9 @@ data:
   REAPER_DEFAULT_BACKOFF: "{{ $.Values.mirror.reaper.defaultBackoff }}"
   STREAM_FILE_EXTENSION: "rcd"
   STREAM_SIG_EXTENSION: "rcd_sig"
-  STREAM_EXTENSION: "rcd"
+  STREAM_EXTENSION: {{ $.Values.mirror.recordStream.compression | ternary "rcd.gz" "rcd" }}
+  RECORD_STREAM_COMPRESSION: "{{ $.Values.mirror.recordStream.compression }}"
+  RECORD_STREAM_SIDECAR: "{{ $.Values.mirror.recordStream.sidecar }}"
   S3_ENABLE: "{{ $.Values.mirror.s3.enable }}"
   GCS_ENABLE: "{{ $.Values.mirror.gcs.enable }}"
   SIG_REQUIRE: "{{ $.Values.mirror.sig.require }}"

--- a/charts/hedera-network/templates/network-node-statefulset.yaml
+++ b/charts/hedera-network/templates/network-node-statefulset.yaml
@@ -136,7 +136,7 @@ spec:
             mountPath: /opt/hgcapp/
         envFrom:
           - configMapRef:
-              name: record-stream-sidecar-config
+              name: record-stream-uploader-config
           - secretRef:
               name: uploader-secrets
   {{ end }}

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -61,6 +61,8 @@ mirror:
     csvStatsDir: /opt/hgcapp/recordstream/uploader-stats/
     bucketPath: /recordstream
     bucketName: "dev"
+    compression: true
+    sidecar: true
   recordStreamSideCar:
     watchDir: /opt/hgcapp/sidecar
     bucketPath: /recordstreamsidecar


### PR DESCRIPTION
## Description

This PR fixes
-  The config in the configmap:  [record-stream-uploader-config]
-  deletes configmap  [record-stream-sidecar-config]
- source of truth: https://github.com/swirlds/infrastructure/blob/79db20d59c357905bf8895ff8fb524e5bbd8a4e0/mainnet/ansible/roles/uploader-mirror/templates/record.env

## Details

 in the configmap record-stream-sidecar-config
This config is
incorrect: STREAM_EXTENSION: "rcd"
correct: STREAM_EXTENSION: {{ $.Values.mirror.recordStream.compression | ternary "rcd.gz" "rcd" }}

this config is missing :
RECORD_STREAM_COMPRESSION: "{{ $.Values.mirror.recordStream.compression }}"
RECORD_STREAM_SIDECAR: "{{ $.Values.mirror.recordStream.sidecar }}"

2 config maps are used
current: [ record-stream-sidecar-config, record-stream-uploader-config ]
neeed: [ record-stream-uploader-config ]

### Related Issues

- Closes #149 
