### PR TITLE
chore(deps): force kind version to v0.19.0

### DIFF
--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -102,6 +102,7 @@ jobs:
         uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # pin@v1
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
         with:
+          version: v0.19.0
           verbosity: 3
           wait: 120s
 


### PR DESCRIPTION
## Description

This pull request changes the following:

- Force kind version to `v0.19.0` to fix failure introduced in kind `v0.20.0` via the dependabot update of the `kind-action` step.

### Related Issues

- #181 
