### PR TITLE
chore: remove unused 2nd bucket name and rename + restructure location of value

### DIFF
--- a/charts/hedera-network/templates/configmaps/backup-configmap.yaml
+++ b/charts/hedera-network/templates/configmaps/backup-configmap.yaml
@@ -3,5 +3,4 @@ kind: ConfigMap
 metadata:
   name: backup-config
 data:
-  BACKUP_UPLOADER_BUCKET_1: {{ .Values.sidecars.backup.bucket1 }}
-  BACKUP_UPLOADER_BUCKET_2: {{ .Values.sidecars.backup.bucket2 }}
+  BACKUP_UPLOADER_BUCKET_1: {{ .Values.backupUploaderBucket }}

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -155,9 +155,8 @@ sidecars:
         mountPath: /etc/otel-collector-config.yaml
         subPath: config.yaml #key in the configmap
         readOnly: true
-  backup:
-    bucket1: backup-1
-    bucket2: backup-2
 
 # reduce default termination grace period
 terminationGracePeriodSeconds: 10
+# the bucket to use for the hedera network node(s) backup uploader
+backupUploaderBucket: backup-bucket


### PR DESCRIPTION
## Description

This pull request changes the following:

- remove unused 2nd backup uploader bucket
- rename bucket variable
- change bucket var location

### Related Issues

- Closes #160 
