### PR TITLE
fix: resolve build issue with ubi8-init-java17 container image

### DIFF
--- a/docker/ubi8-init-java17/Dockerfile
+++ b/docker/ubi8-init-java17/Dockerfile
@@ -105,7 +105,7 @@ ADD network-node.service /usr/lib/systemd/system/
 RUN chmod -R +x /etc/network-node/entrypoint.sh && \
     chown -R 2000:2000 /opt/hgcapp/
 
-RUN mkdir /etc/network-node && \
+RUN mkdir -p /etc/network-node && \
     touch /etc/network-node/application.env && \
     echo "JAVA_HOME=\"${JAVA_HOME}\"" >> /etc/network-node/java.env && \
     echo "PATH=\"${PATH}\"" >> /etc/network-node/java.env && \


### PR DESCRIPTION
## Description

This pull request changes the following:

- Fixes an issue introduced by #197 
- Adds the `-p` switch to the `mkdir` command to avoid a failure when the directory already exists.

### Related Issues

- Closes #200 
