### PR TITLE
chore: remove the javadoc step from all workflows

### DIFF
--- a/.github/workflows/flow-build-application.yaml
+++ b/.github/workflows/flow-build-application.yaml
@@ -18,11 +18,6 @@ name: "Build Application"
 on:
   workflow_dispatch:
     inputs:
-      enable-javadoc:
-        description: "Javadoc Enabled"
-        type: boolean
-        required: false
-        default: true
       enable-unit-tests:
         description: "Unit Testing Enabled"
         type: boolean
@@ -75,7 +70,6 @@ jobs:
       java-version: ${{ github.event.inputs.java-version || '17.0.7' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
       gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
-      enable-javadoc: ${{ github.event_name == 'push' || github.event.inputs.enable-javadoc == 'true' }}
       enable-unit-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-unit-tests == 'true' }}
       enable-spotless-check: ${{ github.event_name == 'push' || github.event.inputs.enable-spotless-check == 'true' }}
 

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -35,8 +35,6 @@ jobs:
   build:
     name: Code
     uses: ./.github/workflows/zxc-compile-code.yaml
-    with:
-      enable-javadoc: true
 
   spotless:
     name: Spotless

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -18,11 +18,6 @@ name: "ZXC: Compile Code"
 on:
   workflow_call:
     inputs:
-      enable-javadoc:
-        description: "Javadoc Enabled"
-        type: boolean
-        required: false
-        default: false
       enable-unit-tests:
         description: "Unit Testing Enabled"
         type: boolean
@@ -146,13 +141,6 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
-
-      - name: Javadoc
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
-        if: ${{ inputs.enable-javadoc && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: javadoc --scan
 
       - name: Spotless Check
         uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2


### PR DESCRIPTION
## Description

This pull request changes the following:

- Removes the javadoc step from all workflows since it is covered by the Gradle `assemble` task.

### Related Issues

- Closes #204 
