### PR TITLE
chore: remove the expand shallow clone step from the compile workflow

### DIFF
--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -78,6 +78,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        with:
+          fetch-depth: ${{ inputs.enable-spotless-check && '0' || '' }}
 
       - name: Setup Java
         uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # pin@v3


### PR DESCRIPTION
## Description

This pull request changes the following:

- Removes the unused expand shallow clone step from the compile workflow.

### Related Issues

- Closes #205 
