### PR TITLE
fix: default tag is not set properly for proxy containers

### DIFF
--- a/charts/hedera-network/templates/_helpers.tpl
+++ b/charts/hedera-network/templates/_helpers.tpl
@@ -29,6 +29,6 @@ privileged: true
 {{- define "fullstack.container.image" -}}
 {{- $reg := (.image).registry | default .defaults.image.registry -}}
 {{- $repo := (.image).repository | default .defaults.image.repository -}}
-{{- $tag := (.image).tag | default .Chart.AppVersion -}}
+{{- $tag := default .defaults.image.tag (.image).tag | default .Chart.AppVersion -}}
 {{ $reg }}/{{ $repo }}:{{ $tag }}
 {{- end }}

--- a/charts/hedera-network/templates/proxy/envoy-deployment.yaml
+++ b/charts/hedera-network/templates/proxy/envoy-deployment.yaml
@@ -1,6 +1,6 @@
 {{ range $index, $node := ($.Values.hedera.nodes) }}
 {{- $envoyProxy := $node.envoyProxy | default dict -}}
-{{- $defaults := $.Values.defaults.haproxy }}
+{{- $defaults := $.Values.defaults.envoyProxy }}
 {{- if default $defaults.enable $envoyProxy.enable | eq "true" }}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
## Description

This pull request changes the following:

- add the fix so that haproxy and envoy-proxy uses the default image tag instead of using Chart.AppVersion

### Related Issues

- Closes #264
