### PR TITLE
feat: add service definitions for HAProxy and Envoy with support for both ClusterIP and LoadBalancer configurations

### DIFF
--- a/charts/hedera-network/config-files/envoy.yaml
+++ b/charts/hedera-network/config-files/envoy.yaml
@@ -39,7 +39,7 @@ static_resources:
                   - name: envoy.filters.http.cors
                   - name: envoy.filters.http.router
   clusters:
-    - name: echo_service
+    - name: non_tls_grpc_cluster
       connect_timeout: 0.25s
       type: logical_dns
       http2_protocol_options: {}

--- a/charts/hedera-network/templates/services/envoy-svc.yaml
+++ b/charts/hedera-network/templates/services/envoy-svc.yaml
@@ -14,7 +14,7 @@ spec:
   selector:
     app: envoy-proxy-{{ $node.name }}
   ports:
-    - port: 8080 # dynamic?
+    - port: 8080
       targetPort: 8080
 {{- end }}
 {{- end }}

--- a/charts/hedera-network/templates/services/envoy-svc.yaml
+++ b/charts/hedera-network/templates/services/envoy-svc.yaml
@@ -1,0 +1,24 @@
+{{ range $index, $node := ($.Values.hedera.nodes) }}
+{{- $envoyProxy := $node.envoyProxy | default dict -}}
+{{- $defaults := $.Values.defaults.haproxy }}
+{{- if default $defaults.enable $envoyProxy.enable | eq "true" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-proxy-{{ $node.name }}-svc
+spec:
+  {{- if $envoyProxy.externalPortEnabled }}
+  type: LoadBalancer
+  {{- end }}
+  selector:
+    app: envoy-proxy-{{ $node.name }}
+  ports:
+    - port: 8080 # dynamic?
+      targetPort: 8080
+      {{- if $envoyProxy.externalPortEnabled }}
+      nodePort: {{ $node.externalEnvoyPort }}
+      {{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/hedera-network/templates/services/envoy-svc.yaml
+++ b/charts/hedera-network/templates/services/envoy-svc.yaml
@@ -8,7 +8,7 @@ kind: Service
 metadata:
   name: envoy-proxy-{{ $node.name }}-svc
 spec:
-  {{- if $envoyProxy.externalPortEnabled }}
+  {{- if $envoyProxy.loadBalancerEnabled }}
   type: LoadBalancer
   {{- end }}
   selector:
@@ -16,9 +16,6 @@ spec:
   ports:
     - port: 8080 # dynamic?
       targetPort: 8080
-      {{- if $envoyProxy.externalPortEnabled }}
-      nodePort: {{ $node.externalEnvoyPort }}
-      {{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/hedera-network/templates/services/envoy-svc.yaml
+++ b/charts/hedera-network/templates/services/envoy-svc.yaml
@@ -8,7 +8,7 @@ kind: Service
 metadata:
   name: envoy-proxy-{{ $node.name }}-svc
 spec:
-  {{- if $envoyProxy.loadBalancerEnabled }}
+  {{- if default $defaults.loadBalancerEnabled $envoyProxy.loadBalancerEnabled | eq "true" }}
   type: LoadBalancer
   {{- end }}
   selector:

--- a/charts/hedera-network/templates/services/haproxy-svc.yaml
+++ b/charts/hedera-network/templates/services/haproxy-svc.yaml
@@ -14,9 +14,11 @@ spec:
   selector:
     app: haproxy-{{ $node.name }}
   ports:
-    - port: 50211
+    - name: non-tls-grpc-client-port
+      port: 50211
       targetPort: 50211
-    - port: 50212
+    - name: tls-grpc-client-port
+      port: 50212
       targetPort: 50212
 {{- end }}
 {{- end }}

--- a/charts/hedera-network/templates/services/haproxy-svc.yaml
+++ b/charts/hedera-network/templates/services/haproxy-svc.yaml
@@ -1,0 +1,24 @@
+{{- range $index, $node := ($.Values.hedera.nodes) }}
+{{- $haproxy := $node.haproxy | default dict -}}
+{{- $defaults := $.Values.defaults.haproxy }}
+{{- if default $defaults.enable $haproxy.enable | eq "true" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: haproxy-{{ $node.name }}-svc
+spec:
+  {{- if $haproxy.externalPortEnabled }}
+  type: LoadBalancer
+  {{- end }}
+  selector:
+    app: haproxy-{{ $node.name }}
+  ports:
+    - port: 14567
+      targetPort: 14567
+      {{- if $haproxy.externalPortEnabled }}
+      nodePort: {{ $node.externalHaproxyPort }}
+      {{- end }}
+{{- end }}
+{{- end }}
+

--- a/charts/hedera-network/templates/services/haproxy-svc.yaml
+++ b/charts/hedera-network/templates/services/haproxy-svc.yaml
@@ -8,17 +8,14 @@ kind: Service
 metadata:
   name: haproxy-{{ $node.name }}-svc
 spec:
-  {{- if $haproxy.externalPortEnabled }}
+  {{- if $haproxy.loadBalancerEnabled }}
   type: LoadBalancer
   {{- end }}
   selector:
     app: haproxy-{{ $node.name }}
   ports:
-    - port: 14567
+    - port: 14567 # this is telemetry/stats, not needed
       targetPort: 14567
-      {{- if $haproxy.externalPortEnabled }}
-      nodePort: {{ $node.externalHaproxyPort }}
-      {{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/hedera-network/templates/services/haproxy-svc.yaml
+++ b/charts/hedera-network/templates/services/haproxy-svc.yaml
@@ -14,8 +14,10 @@ spec:
   selector:
     app: haproxy-{{ $node.name }}
   ports:
-    - port: 14567 # this is telemetry/stats, not needed
-      targetPort: 14567
+    - port: 50211
+      targetPort: 50211
+    - port: 50212
+      targetPort: 50212
 {{- end }}
 {{- end }}
 

--- a/charts/hedera-network/templates/services/haproxy-svc.yaml
+++ b/charts/hedera-network/templates/services/haproxy-svc.yaml
@@ -8,7 +8,7 @@ kind: Service
 metadata:
   name: haproxy-{{ $node.name }}-svc
 spec:
-  {{- if $haproxy.loadBalancerEnabled }}
+  {{- if default $defaults.loadBalancerEnabled $haproxy.loadBalancerEnabled | eq "true" }}
   type: LoadBalancer
   {{- end }}
   selector:

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -49,7 +49,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    loadBalancerEnabled: "true" # default to false before merge
+    loadBalancerEnabled: "false"
   envoyProxy:
     enable: "true"
     nameOverride: "envoy-proxy"
@@ -60,7 +60,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    loadBalancerEnabled: "true" # default to false before merge
+    loadBalancerEnabled: "false"
   sidecars:
     recordStreamUploader:
       enable: "true"

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -49,8 +49,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    # default to false before merge
-    loadBalancerEnabled: "true"
+    loadBalancerEnabled: "true" # default to false before merge
   envoyProxy:
     enable: "true"
     nameOverride: "envoy-proxy"
@@ -61,8 +60,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    # default to false before merge
-    loadBalancerEnabled: "true"
+    loadBalancerEnabled: "true" # default to false before merge
   sidecars:
     recordStreamUploader:
       enable: "true"

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -49,7 +49,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    externalPortEnabled: "false"
+    loadBalancerEnabled: "false"
   envoyProxy:
     enable: "true"
     nameOverride: "envoy-proxy"
@@ -60,7 +60,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    externalPortEnabled: "false"
+    loadBalancerEnabled: "false"
   sidecars:
     recordStreamUploader:
       enable: "true"
@@ -164,15 +164,8 @@ defaults:
 
 # hedera node configuration
 # Only the name of the node is required. The rest of the configuration will be inherited from `defaults` section
-# the external ports are needed if the nodes externalPortEnabled is true
 hedera:
   nodes:
     - name: node0
-      externalHaproxyPort: 30000
-      externalEnvoyPort: 31000
     - name: node1
-      externalHaproxyPort: 30001
-      externalEnvoyPort: 31001
     - name: node2
-      externalHaproxyPort: 30002
-      externalEnvoyPort: 31002

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -49,6 +49,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
+    externalPortEnabled: "false"
   envoyProxy:
     enable: "true"
     nameOverride: "envoy-proxy"
@@ -59,6 +60,7 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
+    externalPortEnabled: "false"
   sidecars:
     recordStreamUploader:
       enable: "true"
@@ -162,8 +164,15 @@ defaults:
 
 # hedera node configuration
 # Only the name of the node is required. The rest of the configuration will be inherited from `defaults` section
+# the external ports are needed if the nodes externalPortEnabled is true
 hedera:
   nodes:
     - name: node0
+      externalHaproxyPort: 30000
+      externalEnvoyPort: 31000
     - name: node1
+      externalHaproxyPort: 30001
+      externalEnvoyPort: 31001
     - name: node2
+      externalHaproxyPort: 30002
+      externalEnvoyPort: 31002

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -49,7 +49,8 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    loadBalancerEnabled: "false"
+    # default to false before merge
+    loadBalancerEnabled: "true"
   envoyProxy:
     enable: "true"
     nameOverride: "envoy-proxy"
@@ -60,7 +61,8 @@ defaults:
       pullPolicy: "IfNotPresent"
     replica: 1
     resources: {}
-    loadBalancerEnabled: "false"
+    # default to false before merge
+    loadBalancerEnabled: "true"
   sidecars:
     recordStreamUploader:
       enable: "true"


### PR DESCRIPTION
## Description

This pull request changes the following:

- update envoy cluster name from echo_service to non_tls_grpc_cluster
- add HAProxy and Envoy service definitions with support for both ClusterIP and LoadBalancer configurations

### Related Issues

- Closes #225 
