### PR TITLE
chore: update CI workflow definitions with version numbers and comments for clarity

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -54,12 +54,12 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # pin@v3
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # v3.8.0
         with:
           node-version: 18
 
@@ -109,23 +109,23 @@ jobs:
       - prepare-release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # pin@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Qemu
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # pin@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # pin@v2
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2.9.1
 
       - name: Build Docker Image (ubi8-init-dind)
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # pin@v4
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
           context: docker/ubi8-init-dind
           cache-from: type=gha
@@ -135,7 +135,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/ubi8-init-dind:${{ needs.prepare-release.outputs.version }}
 
       - name: Build Docker Image (ubi8-init-java17)
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # pin@v4
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
           context: docker/ubi8-init-java17
           cache-from: type=gha
@@ -145,7 +145,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/ubi8-init-java17:${{ needs.prepare-release.outputs.version }}
 
       - name: Build Docker Image (kubectl-bats)
-        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # pin@v4
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
           context: docker/kubectl-bats
           cache-from: type=gha
@@ -163,7 +163,7 @@ jobs:
     if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: 0
@@ -181,7 +181,7 @@ jobs:
 
       - name: Import GPG key
         id: gpg_key
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # pin@v5
+        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
         with:
           gpg_private_key: ${{ secrets.GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.GPG_KEY_PASSPHRASE }}
@@ -191,13 +191,13 @@ jobs:
           git_tag_gpgsign: false
 
       - name: Setup Java
-        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # pin@v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: wrapper
           gradle-home-cache-includes: |
@@ -206,7 +206,7 @@ jobs:
             dependency-check-data
 
       - name: Setup Node
-        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # pin@v3
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # v3.8.0
         with:
           node-version: 18
 

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -15,6 +15,13 @@
 ##
 
 name: "ZXC: Code Analysis"
+# The purpose of this reusable workflow is to perform static code analysis and code coverage reporting.
+# This reusable component is called by the following workflows:
+# - .github/workflows/flow-pull-request-checks.yaml
+# - .github/workflows/flow-build-application.yaml
+#
+# This workflow is only run if the pull request is coming from the original repository and not a fork.
+
 on:
   workflow_call:
     inputs:
@@ -86,27 +93,25 @@ jobs:
     runs-on: [self-hosted, Linux, medium, ephemeral]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
-
-      - name: Expand Shallow Clone for SonarQube
-        if: ${{ inputs.enable-sonar-analysis && !cancelled() }}
-        run: git fetch --unshallow --no-recurse-submodules
+          fetch-depth: ${{ inputs.enable-sonar-analysis && '0' || '' }}
 
       - name: Setup Java
-        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # pin@v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: ${{ inputs.gradle-version }}
 
+      # Node.JS 16.x is required for the Snyk CLI, Sonar Scan, and CodeCov steps below.
       - name: Setup Node
-        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # pin@v3
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # v3.8.0
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -117,8 +122,8 @@ jobs:
           name: Coverage Reports
 
       - name: Publish To Codecov
+        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # pin@v3
         env:
           CODECOV_TOKEN: ${{ secrets.codecov-token }}
 
@@ -136,7 +141,7 @@ jobs:
           echo "options=${SONAR_OPTS}" >> "${GITHUB_OUTPUT}"
 
       - name: SonarCloud Scan
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.access-token }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}
@@ -182,7 +187,7 @@ jobs:
           fi
 
       - name: Publish Snyk Reports
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ inputs.enable-snyk-scan && !cancelled() && !failure() }}
         with:
           name: Snyk Reports

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -15,6 +15,11 @@
 ##
 
 name: "ZXC: Compile Code"
+# The purpose of this reusable workflow is to compile the code and run the unit tests on every PR and commit.
+# This reusable component is called by the following workflows:
+# - .github/workflows/flow-pull-request-checks.yaml
+# - .github/workflows/flow-build-application.yaml
+
 on:
   workflow_call:
     inputs:
@@ -72,28 +77,29 @@ jobs:
     runs-on: [self-hosted, Linux, medium, ephemeral]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
+          # the fetch depth defaults to only the commit that triggered the workflow unless the spotless check was enabled
           fetch-depth: ${{ inputs.enable-spotless-check && '0' || '' }}
 
       - name: Setup Java
-        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # pin@v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: ${{ inputs.gradle-version }}
 
       - name: Setup Node
-        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # pin@v3
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # v3.8.0
         with:
           node-version: ${{ inputs.node-version }}
 
       - name: Setup Kind
-        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # pin@v1
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
         with:
           version: v0.19.0
@@ -101,10 +107,10 @@ jobs:
           wait: 120s
 
       - name: Setup Helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # pin@v3.5
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
         with:
-          version: "v3.12.1" # helm version
+          version: "v3.12.3" # helm version
 
       - name: Setup Kubernetes Operators
         working-directory: dev
@@ -112,6 +118,7 @@ jobs:
         run: |
           make deploy-prometheus-operator
 
+      # Technically, this step is not required for the unit tests to run, but it is useful for debugging setup issues.
       - name: Kubernetes Cluster Info
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
         run: |
@@ -119,24 +126,30 @@ jobs:
           kubectl config get-contexts
           kubectl get crd
 
+      # This step is currently required because the Hedera Services artifacts are not publicly accessible.
+      # May be removed once the artifacts are publicly accessible.
       - name: Authenticate to Google Cloud
         id: google-auth
+        uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # v1.1.1
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
-        uses: google-github-actions/auth@35b0e87d162680511bf346c299f71c9c5c379033 # pin@v1
         with:
           token_format: 'access_token'
           workload_identity_provider: "projects/101730247931/locations/global/workloadIdentityPools/hedera-registry-pool/providers/hedera-registry-gh-actions"
           service_account: "swirlds-automation@hedera-registry.iam.gserviceaccount.com"
 
+      # This step is currently required because the Hedera Services artifacts are not publicly accessible.
+      # May be removed once the artifacts are publicly accessible.
       - name: Setup Google Cloud SDK
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
-        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # pin@v1
+        uses: google-github-actions/setup-gcloud@e30db14379863a8c79331b04a9969f4c1e225e0b # v1.1.1
 
+      # This step tests the Helm chart direct mode of operation which uses the ubi8-init-java17 image.
       - name: Helm Chart Test (Direct Install)
         working-directory: dev
         if: ${{ inputs.enable-unit-tests && !cancelled() && !failure() }}
         run: make test SCRIPT_NAME=direct-install.sh
 
+      # This step tests the Helm chart NMT mode of operation which uses the ubi8-init-dind image.
       - name: Helm Chart Test (NMT Install)
         working-directory: dev
         if: ${{ inputs.enable-unit-tests && !cancelled() && !failure() }}
@@ -144,28 +157,28 @@ jobs:
 
       - name: Compile
         id: gradle-build
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
 
       - name: Spotless Check
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         if: ${{ inputs.enable-spotless-check && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
 
-      - name: Unit Testing
+      - name: Unit Tests
         id: gradle-test
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() && !failure() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
 
       - name: Publish Unit Test Report
-        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # pin@v2
+        uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() && !failure() }}
         with:
           check_name: 'Unit Test Results'
@@ -173,22 +186,24 @@ jobs:
           json_thousands_separator: ','
           junit_files: "**/build/test-results/test/TEST-*.xml"
 
+      # Technically, this step is not required since the Gradle check task implicitly includes it but is executed again
+      # here to prevent failures if future modules are not wired properly.
       - name: Jacoco Coverage Report
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: jacocoTestReport --scan
 
       - name: Publish Jacoco Coverage Report
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ inputs.enable-unit-tests && !cancelled() }}
         with:
           name: Coverage Reports
           path: '**/jacocoTestReport.xml'
 
       - name: Publish Test Reports
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         with:
           name: Test Reports

--- a/.github/workflows/zxc-release-maven-central.yaml
+++ b/.github/workflows/zxc-release-maven-central.yaml
@@ -15,6 +15,10 @@
 ##
 
 name: "ZXC: Release Maven Central"
+# The purpose of this reusable workflow is to release a new version to Maven Central.
+# This reusable component is called by the following workflows:
+# - .github/workflows/flow-release-maven-central.yaml
+
 on:
   workflow_call:
     inputs:
@@ -81,10 +85,11 @@ jobs:
       notes: ${{ steps.create-release-notes.outputs.RELEASE_NOTES }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           fetch-depth: 0
 
+      # This step is required for some self-hosted runners because the default gpg does not include the gpg2 command.
       - name: Install GnuPG Tools
         run: |
           if ! command -v gpg2 >/dev/null 2>&1; then
@@ -98,7 +103,7 @@ jobs:
 
       - name: Import GPG key
         id: gpg_key
-        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # pin@v5
+        uses: crazy-max/ghaction-import-gpg@72b6676b71ab476b77e676928516f6982eef7a41 # v5.3.0
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         with:
           gpg_private_key: ${{ secrets.gpg-key-contents }}
@@ -109,13 +114,13 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Setup Java
-        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # pin@v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: ${{ inputs.gradle-version }}
           gradle-home-cache-includes: |
@@ -123,36 +128,37 @@ jobs:
             notifications
             dependency-check-data
 
+      # This step is used to update the version number in the build.properties file.
       - name: Apply Version Number Update (Explicit)
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: versionAsSpecified --scan -PnewVersion=${{ inputs.new-version }}
 
+      # Technically, this step is not required but is executed to provide the end users with a summary of the version
+      # numbers assigned to each published artifact.
       - name: Version Report
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: githubVersionSummary --scan
 
+      # Technically, this step is not required because the release steps will build what is required; however,
+      # if one or more components fails to build then it could result in a partial publish to Maven Central.
+      # The inclusion of this step ensures the job fails cleanly without publishing to Maven Central if any of the
+      # components fail to build.
       - name: Gradle Assemble
         id: gradle-build
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
 
-      - name: Gradle JavaDoc
-        id: gradle-javadoc
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
-        if: ${{ steps.gradle-build.conclusion == 'success' && !cancelled() && !failure() }}
-        with:
-          gradle-version: ${{ inputs.gradle-version }}
-          arguments: javadoc --scan
-
-      - name: Gradle Deploy
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+      # Publishes the artifacts to the Maven Central Nexus staging repository. A manual step is required to release
+      # the artifacts from the staging repository to Maven Central.
+      - name: Gradle Publish to Maven Central
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         if: ${{ inputs.dry-run-enabled != true && !cancelled() && !failure() }}
         env:
           OSSRH_USERNAME: ${{ secrets.ossrh-user-name }}

--- a/.github/workflows/zxf-snyk-monitor.yaml
+++ b/.github/workflows/zxf-snyk-monitor.yaml
@@ -15,6 +15,8 @@
 ##
 
 name: "ZXF: Snyk Monitor"
+# The purpose of this job is to run on each commit to the main branch and daily at midnight UTC on the most recent commit.
+# This job is not intended to be run manually, but rather to be run when triggered by either a commit or the schedule.
 
 on:
   push:
@@ -32,26 +34,30 @@ jobs:
     runs-on: [self-hosted, Linux, medium, ephemeral]
     steps:
       - name: Checkout
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
 
       - name: Setup Java
-        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # pin@v3
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
         with:
           distribution: temurin
           java-version: 17.0.7
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: wrapper
 
+      # Node.JS 16.x is required for the Snyk CLI.
       - name: Setup NodeJS
-        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # pin@v3
+        uses: actions/setup-node@bea5baf987ba7aa777a8a0b4ace377a21c45c381 # v3.8.0
         with:
           node-version: 16
 
+      # This step may be optional since Snyk analysis does not require the binary artifacts to be built first. However,
+      # Snyk will fail if the code does not compile and the error messages are less than helpful. Therefore, we will
+      # compile the code first and then run Snyk so that we can get diagnostic information if the code does not compile.
       - name: Compile
-        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # pin@v2
+        uses: gradle/gradle-build-action@a4cf152f482c7ca97ef56ead29bf08bcd953284c # v2.7.0
         with:
           gradle-version: wrapper
           arguments: assemble --scan
@@ -59,6 +65,8 @@ jobs:
       - name: Setup Snyk
         run: npm install -g snyk
 
+      # This step is what actually uploads the Snyk analysis to the Snyk Cloud. The Snyk token is stored as a secret
+      # in the Github repository and is passed to the Snyk CLI via the environment variable SNYK_TOKEN.
       - name: Run Snyk Monitor
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/buildSrc/src/main/kotlin/com/hedera/fullstack/gradle/helm/release/HelmArtifactTask.kt
+++ b/buildSrc/src/main/kotlin/com/hedera/fullstack/gradle/helm/release/HelmArtifactTask.kt
@@ -21,7 +21,7 @@ import kotlin.io.path.exists
 @CacheableTask
 abstract class HelmArtifactTask() : DefaultTask() {
     @get:Input
-    val version: Property<String> = project.objects.property(String::class.java).convention("3.12.0")
+    val version: Property<String> = project.objects.property(String::class.java).convention("3.12.3")
 
     @get:Input
     val tuples: ListProperty<ArtifactTuple> = project.objects.listProperty(ArtifactTuple::class.java).convention(

--- a/charts/hedera-network/Chart.yaml
+++ b/charts/hedera-network/Chart.yaml
@@ -29,12 +29,12 @@ kubeVersion: ">=1.25.0"
 dependencies:
   - name: hedera-mirror
     alias: hedera-mirror-node
-version: 0.7.0
+    version: 0.86.0
     repository: https://hashgraph.github.io/hedera-mirror-node/charts
     condition: cloud.minio.enable
 
   - name: tenant
     alias: minio-server
-version: 0.7.0
+    version: 5.0.7
     repository: https://operator.min.io/
     condition: cloud.minio.enable


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates the default Helm CLI version used by both the Gradle plugin and by the CI pipelines.
- Adds version number comments to the end of each and every third-party Github Actions step uses line.
- Adds general comments to the CI pipelines where additional clarity is needed.

### Related Issues

- Closes #282 
