### PR TITLE
feat: add helm execution gradle task: HelmInstallChartTask

### DIFF
--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -170,6 +170,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
           build-root-directory: fullstack-examples
+          gradle-executable: fullstack-testing/gradlew
 
       - name: Spotless Check
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
@@ -185,6 +186,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
           build-root-directory: fullstack-examples
+          gradle-executable: fullstack-testing/gradlew
 
       - name: Unit Tests
         id: gradle-test
@@ -202,6 +204,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
           build-root-directory: fullstack-examples
+          gradle-executable: fullstack-testing/gradlew
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -163,6 +163,14 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
 
+      - name: Examples Compile
+        id: gradle-build
+        uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
+        with:
+          gradle-version: ${{ inputs.gradle-version }}
+          arguments: assemble --scan
+          build-root-directory: fullstack-examples
+
       - name: Spotless Check
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
         if: ${{ inputs.enable-spotless-check && steps.gradle-build.conclusion == 'success' && !cancelled() }}
@@ -177,6 +185,15 @@ jobs:
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
+
+      - name: Examples Unit Tests
+        id: gradle-test
+        uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
+        if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() && !failure() }}
+        with:
+          gradle-version: ${{ inputs.gradle-version }}
+          arguments: check --scan
+          build-root-directory: fullstack-examples
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -170,7 +170,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
           build-root-directory: fullstack-examples
-          gradle-executable: ../
+          gradle-executable: ../gradlew
 
       - name: Spotless Check
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
@@ -186,7 +186,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
           build-root-directory: fullstack-examples
-          gradle-executable: ../
+          gradle-executable: ../gradlew
 
       - name: Unit Tests
         id: gradle-test
@@ -204,7 +204,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
           build-root-directory: fullstack-examples
-          gradle-executable: ../
+          gradle-executable: ../gradlew
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -178,6 +178,14 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
 
+      - name: Examples Spotless Check
+        uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
+        if: ${{ inputs.enable-spotless-check && steps.gradle-build-examples.conclusion == 'success' && !cancelled() }}
+        with:
+          gradle-version: ${{ inputs.gradle-version }}
+          arguments: spotlessCheck --scan
+          build-root-directory: fullstack-examples
+
       - name: Unit Tests
         id: gradle-test
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -164,7 +164,7 @@ jobs:
           arguments: assemble --scan
 
       - name: Examples Compile
-        id: gradle-build
+        id: gradle-build-examples
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
         with:
           gradle-version: ${{ inputs.gradle-version }}
@@ -187,9 +187,9 @@ jobs:
           arguments: check --scan
 
       - name: Examples Unit Tests
-        id: gradle-test
+        id: gradle-test-examples
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
-        if: ${{ inputs.enable-unit-tests && steps.gradle-build.conclusion == 'success' && !cancelled() && !failure() }}
+        if: ${{ inputs.enable-unit-tests && steps.gradle-build-examples.conclusion == 'success' && !cancelled() && !failure() }}
         with:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -170,7 +170,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
           build-root-directory: fullstack-examples
-          gradle-executable: fullstack-testing/gradlew
+          gradle-executable: gradlew
 
       - name: Spotless Check
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
@@ -186,7 +186,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
           build-root-directory: fullstack-examples
-          gradle-executable: fullstack-testing/gradlew
+          gradle-executable: gradlew
 
       - name: Unit Tests
         id: gradle-test
@@ -204,7 +204,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
           build-root-directory: fullstack-examples
-          gradle-executable: fullstack-testing/gradlew
+          gradle-executable: gradlew
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -170,7 +170,6 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
           build-root-directory: fullstack-examples
-          gradle-executable: ../gradlew
 
       - name: Spotless Check
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
@@ -186,7 +185,6 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
           build-root-directory: fullstack-examples
-          gradle-executable: ../gradlew
 
       - name: Unit Tests
         id: gradle-test
@@ -204,7 +202,6 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
           build-root-directory: fullstack-examples
-          gradle-executable: ../gradlew
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -170,6 +170,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: assemble --scan
           build-root-directory: fullstack-examples
+          gradle-executable: ../
 
       - name: Spotless Check
         uses: gradle/gradle-build-action@243af859f8ca30903d9d7f7936897ca0358ba691 # v2.7.1
@@ -185,6 +186,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: spotlessCheck --scan
           build-root-directory: fullstack-examples
+          gradle-executable: ../
 
       - name: Unit Tests
         id: gradle-test
@@ -202,6 +204,7 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
           arguments: check --scan
           build-root-directory: fullstack-examples
+          gradle-executable: ../
 
       - name: Publish Unit Test Report
         uses: actionite/publish-unit-test-result-action@1e01e49081c6c4073913aa4b7980fa83e709f322 # v2.3.0

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.jpms-modules.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.jpms-modules.gradle.kts
@@ -22,8 +22,6 @@ plugins {
 }
 
 javaModuleDependencies {
-    versionsFromConsistentResolution(":fullstack-helm-client")
-
     moduleNameToGA.put("com.hedera.fullstack.junit.support", "com.hedera.fullstack:fullstack-junit-support")
     moduleNameToGA.put("com.hedera.fullstack.test.toolkit", "com.hedera.fullstack:fullstack-test-toolkit")
 }

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.root.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.root.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Hedera Hashgraph, LLC
+ *
+ * This software is the confidential and proprietary information of
+ * Hedera Hashgraph, LLC. ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Hedera Hashgraph.
+ *
+ * HEDERA HASHGRAPH MAKES NO REPRESENTATIONS OR WARRANTIES ABOUT THE SUITABILITY OF
+ * THE SOFTWARE, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE, OR NON-INFRINGEMENT. HEDERA HASHGRAPH SHALL NOT BE LIABLE FOR
+ * ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF USING, MODIFYING OR
+ * DISTRIBUTING THIS SOFTWARE OR ITS DERIVATIVES.
+ */
+
+plugins {
+    id("com.autonomousapps.dependency-analysis")
+    id("com.hedera.fullstack.aggregate-reports")
+    id("com.hedera.fullstack.spotless-conventions")
+    id("com.hedera.fullstack.spotless-kotlin-conventions")
+}

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.umbrella.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.umbrella.gradle.kts
@@ -1,7 +1,0 @@
-
-plugins {
-    id("com.autonomousapps.dependency-analysis")
-    id("com.hedera.fullstack.aggregate-reports")
-    id("com.hedera.fullstack.spotless-conventions")
-    id("com.hedera.fullstack.spotless-kotlin-conventions")
-}

--- a/build-logic/settings-plugins/build.gradle.kts
+++ b/build-logic/settings-plugins/build.gradle.kts
@@ -14,6 +14,15 @@
  * limitations under the License.
  */
 
-includeBuild("project-plugins")
+plugins {
+    `kotlin-dsl`
+}
 
-includeBuild("settings-plugins")
+repositories {
+    gradlePluginPortal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.gradle:gradle-enterprise-gradle-plugin:3.14.1")
+}

--- a/build-logic/settings-plugins/src/main/kotlin/com.hedera.fullstack.settings.settings.gradle.kts
+++ b/build-logic/settings-plugins/src/main/kotlin/com.hedera.fullstack.settings.settings.gradle.kts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("com.gradle.enterprise")
+}
+
+// Enable Gradle Build Scan
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+
+        if (!System.getenv("CI").isNullOrEmpty()) {
+            publishAlways()
+            tag("CI")
+        }
+    }
+}
+
+// Allow projects inside a build to be addressed by dependency coordinates notation.
+// https://docs.gradle.org/current/userguide/composite_builds.html#included_build_declaring_substitutions
+// Some functionality of the 'java-module-dependencies' plugin relies on this.
+includeBuild(".")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-plugins { id("com.hedera.fullstack.umbrella") }
+plugins { id("com.hedera.fullstack.root") }
 
 repositories {
     // mavenLocal() // uncomment to use local maven repository

--- a/fullstack-examples/build.gradle.kts
+++ b/fullstack-examples/build.gradle.kts
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import com.hedera.fullstack.gradle.plugin.HelmInstallChartTask
 
 plugins {
     id("java")
-    id("com.hedera.fullstack.umbrella")
+    id("com.hedera.fullstack.root")
     id("com.hedera.fullstack.conventions")
     id("com.hedera.fullstack.jpms-modules")
     id("com.hedera.fullstack.fullstack-gradle-plugin")

--- a/fullstack-examples/build.gradle.kts
+++ b/fullstack-examples/build.gradle.kts
@@ -13,23 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import com.hedera.fullstack.gradle.plugin.HelmInstallChartTask
 
 plugins {
+    id("java")
+    id("com.hedera.fullstack.umbrella")
     id("com.hedera.fullstack.conventions")
     id("com.hedera.fullstack.jpms-modules")
+    id("com.hedera.fullstack.fullstack-gradle-plugin")
 }
 
-dependencies { api(platform(project(":fullstack-bom"))) }
-
-testing {
-    suites {
-        @Suppress("UnstableApiUsage", "unused")
-        val fullstack by
-            registering(JvmTestSuite::class) {
-                useJUnitJupiter()
-                dependencies { implementation(project(":fullstack-examples")) }
-            }
-    }
+dependencies {
+    api(platform("com.hedera.fullstack:fullstack-bom"))
+    implementation("com.hedera.fullstack:fullstack-readiness-api")
+    implementation("com.hedera.fullstack:fullstack-monitoring-api")
+    implementation("com.hedera.fullstack:fullstack-test-toolkit")
+    implementation("com.hedera.fullstack:fullstack-validator-api")
 }
 
-tasks.assemble.configure { dependsOn(tasks.named("fullstackClasses")) }
+tasks.register<HelmInstallChartTask>("helmInstallFstChart") {
+    createNamespace.set(true)
+    namespace.set("fst-ns")
+    release.set("fst")
+    chart.set("../charts/hedera-network")
+}
+
+tasks.register<HelmInstallChartTask>("helmInstallNginxChart") {
+    createNamespace.set(true)
+    namespace.set("nginx-ns")
+    release.set("nginx-release")
+    chart.set("oci://ghcr.io/nginxinc/charts/nginx-ingress")
+}
+
+// TODO: task register helmUninstallNginxChart
+
+tasks.check {
+    dependsOn("helmInstallNginxChart")
+    // TODO: depends on helmUninstallNginxChart
+}

--- a/fullstack-examples/settings.gradle.kts
+++ b/fullstack-examples/settings.gradle.kts
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
-includeBuild("project-plugins")
+pluginManagement {
+    includeBuild("../build-logic")
+    includeBuild("..")
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-includeBuild("settings-plugins")
+rootProject.name = "fullstack-examples"
+
+includeBuild("..")

--- a/fullstack-gradle-plugin/build.gradle.kts
+++ b/fullstack-gradle-plugin/build.gradle.kts
@@ -14,6 +14,27 @@
  * limitations under the License.
  */
 
-plugins { id("com.hedera.fullstack.conventions") }
+plugins {
+    id("java-gradle-plugin")
+    id("com.gradle.plugin-publish").version("1.2.1")
+    id("com.hedera.fullstack.conventions")
+    id("com.hedera.fullstack.maven-publish")
+}
 
-dependencies { api(platform(project(":fullstack-bom"))) }
+dependencies {
+    api(platform(project(":fullstack-bom")))
+    implementation(project(":fullstack-helm-client"))
+}
+
+gradlePlugin {
+    plugins {
+        create("fullstackPlugin") {
+            id = "com.hedera.fullstack.fullstack-gradle-plugin"
+            group = "com.hedera.fullstack"
+            implementationClass = "com.hedera.fullstack.gradle.plugin.FullstackPlugin"
+            displayName = "Fullstack Plugin"
+            description =
+                "The Fullstack Plugin provides tools for working with Fullstack infrastructure."
+        }
+    }
+}

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/FullstackPlugin.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/FullstackPlugin.java
@@ -16,4 +16,12 @@
 
 package com.hedera.fullstack.gradle.plugin;
 
-public class Dummy {}
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class FullstackPlugin implements Plugin<Project> {
+    @Override
+    public void apply(Project project) {
+        // currently no implementation is needed
+    }
+}

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTask.java
@@ -20,6 +20,7 @@ import com.hedera.fullstack.helm.client.HelmClient;
 import com.hedera.fullstack.helm.client.HelmClientBuilder;
 import com.hedera.fullstack.helm.client.model.Chart;
 import com.hedera.fullstack.helm.client.model.install.InstallChartOptionsBuilder;
+import java.util.ArrayList;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
@@ -78,10 +79,10 @@ public abstract class HelmInstallChartTask extends DefaultTask {
             optionsBuilder.createNamespace(getCreateNamespace().get());
         }
         if (getSet().isPresent()) {
-            optionsBuilder.set(getSet().get());
+            optionsBuilder.set(new ArrayList<>(getSet().get()));
         }
         if (getValues().isPresent()) {
-            optionsBuilder.values(getValues().get());
+            optionsBuilder.values(new ArrayList<>(getValues().get()));
         }
         helmClient.installChart(
                 getRelease().getOrNull(),

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTask.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.fullstack.gradle.plugin;
+
+import com.hedera.fullstack.helm.client.HelmClient;
+import com.hedera.fullstack.helm.client.HelmClientBuilder;
+import com.hedera.fullstack.helm.client.model.Chart;
+import com.hedera.fullstack.helm.client.model.install.InstallChartOptionsBuilder;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+public abstract class HelmInstallChartTask extends DefaultTask {
+    @Input
+    @Option(option = "chart", description = "The name of the chart to install")
+    public abstract Property<String> getChart();
+
+    @Input
+    @Optional
+    @Option(option = "createNamespace", description = "Create the release namespace if not present")
+    public abstract Property<Boolean> getCreateNamespace();
+
+    @Input
+    @Optional
+    @Option(option = "namespace", description = "The namespace to use when installing the chart")
+    public abstract Property<String> getNamespace();
+
+    @Input
+    @Option(option = "release", description = "The name of the release to install")
+    public abstract Property<String> getRelease();
+
+    @Input
+    @Optional
+    @Option(option = "repo", description = "The name of the repo to install")
+    public abstract Property<String> getRepo();
+
+    @Input
+    @Optional
+    @Option(
+            option = "set",
+            description =
+                    "set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)")
+    public abstract SetProperty<String> getSet();
+
+    @Input
+    @Optional
+    @Option(option = "values", description = "Specify values in a YAML file or a URL (can specify multiple)")
+    // TODO: enhance to support multiple values files
+    public abstract SetProperty<String> getValues();
+
+    @TaskAction
+    void installChart() {
+        HelmClientBuilder helmClientBuilder = HelmClient.builder();
+        if (getNamespace().isPresent()) {
+            helmClientBuilder.defaultNamespace(getNamespace().get());
+        }
+        HelmClient helmClient = helmClientBuilder.build();
+        InstallChartOptionsBuilder optionsBuilder = InstallChartOptionsBuilder.builder();
+        if (getCreateNamespace().isPresent()) {
+            optionsBuilder.createNamespace(getCreateNamespace().get());
+        }
+        if (getSet().isPresent()) {
+            optionsBuilder.set(getSet().get());
+        }
+        if (getValues().isPresent()) {
+            optionsBuilder.values(getValues().get());
+        }
+        helmClient.installChart(
+                getRelease().getOrNull(),
+                new Chart(getChart().getOrNull(), getRepo().getOrNull()),
+                optionsBuilder.build());
+
+        getProject().getLogger().info("testing...");
+        // TODO log to gradle stdout if there is an error
+    }
+}

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTask.java
@@ -64,7 +64,6 @@ public abstract class HelmInstallChartTask extends DefaultTask {
     @Input
     @Optional
     @Option(option = "values", description = "Specify values in a YAML file or a URL (can specify multiple)")
-    // TODO: enhance to support multiple values files
     public abstract SetProperty<String> getValues();
 
     @TaskAction
@@ -84,12 +83,16 @@ public abstract class HelmInstallChartTask extends DefaultTask {
         if (getValues().isPresent()) {
             optionsBuilder.values(new ArrayList<>(getValues().get()));
         }
-        helmClient.installChart(
-                getRelease().getOrNull(),
-                new Chart(getChart().getOrNull(), getRepo().getOrNull()),
-                optionsBuilder.build());
-
-        getProject().getLogger().info("testing...");
-        // TODO log to gradle stdout if there is an error
+        try {
+            helmClient.installChart(
+                    getRelease().getOrNull(),
+                    new Chart(getChart().getOrNull(), getRepo().getOrNull()),
+                    optionsBuilder.build());
+        } catch (Exception e) {
+            this.getProject()
+                    .getLogger()
+                    .error("HelmInstallChartTask.installChart() An ERROR occurred while installing the chart: ", e);
+            throw e;
+        }
     }
 }

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/package-info.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/package-info.java
@@ -1,1 +1,0 @@
-package com.hedera.fullstack.gradle.plugin;

--- a/fullstack-gradle-plugin/src/main/java/module-info.java
+++ b/fullstack-gradle-plugin/src/main/java/module-info.java
@@ -1,1 +1,0 @@
-module com.hedera.fullstack.gradle.plugin {}

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.fullstack.gradle.plugin;
+
+import static com.hedera.fullstack.base.api.util.ExceptionUtils.suppressExceptions;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.hedera.fullstack.helm.client.HelmClient;
+import com.hedera.fullstack.helm.client.model.Chart;
+import com.hedera.fullstack.helm.client.model.Repository;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HelmInstallChartTaskTest {
+    private static final Repository REPOSITORY = new Repository("stable", "https://charts.helm.sh/stable");
+    private static final Chart CHART = new Chart("mysql", "stable");
+
+    private static final String RELEASE_NAME = "mysql-release";
+
+    private static Project project;
+
+    @BeforeAll
+    static void beforeAll() {
+        project = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    @Disabled("currently this requires manual intervention to run")
+    // 1. 'make deploy-chart'
+    // 2. run this test case, assuming it passes and installs fst
+    // 3. 'make destroy-chart'
+    @DisplayName("Helm Install Chart Task for Hedera Network Chart")
+    void testHelmInstallChartTaskForHederaNetworkChart() throws IOException {
+        HelmClient helmClient = HelmClient.defaultClient();
+        suppressExceptions(() -> helmClient.uninstallChart("fst"));
+        try {
+            final File hederaNetworkChart = new File("../charts/hedera-network");
+            final String hederaNetworkChartPath = hederaNetworkChart.getCanonicalPath();
+            final File valuesFile = new File(hederaNetworkChartPath + File.separator + "values.yaml");
+            final String valuesFilePath = valuesFile.getCanonicalPath();
+            HelmInstallChartTask helmInstallChartTask = project.getTasks()
+                    .create("helmInstallFstChart", HelmInstallChartTask.class, task -> {
+                        task.getChart().set(hederaNetworkChartPath);
+                        task.getRelease().set("fst");
+                        // set image for nmt-install
+                        task.getSet().add("defaults.root.image.repository=hashgraph/full-stack-testing/ubi8-init-dind");
+                        task.getValues().add(valuesFilePath);
+                    });
+            assertEquals("fst", helmInstallChartTask.getRelease().get());
+            helmInstallChartTask.installChart();
+        } finally {
+            // TODO: comment this out as workaround until we no longer need manual use of make command
+            // suppressExceptions(() -> helmClient.uninstallChart("fst"));
+        }
+    }
+
+    @Test
+    @DisplayName("Simple Helm Install Chart Task")
+    void testHelmInstallChartTaskSimple() {
+        HelmClient helmClient =
+                HelmClient.builder().defaultNamespace("simple-test").build();
+        suppressExceptions(() -> helmClient.uninstallChart(RELEASE_NAME));
+        suppressExceptions(() -> helmClient.removeRepository(REPOSITORY));
+        final List<Repository> repositories = helmClient.listRepositories();
+        if (!repositories.contains(REPOSITORY)) {
+            helmClient.addRepository(REPOSITORY);
+        }
+        try {
+            HelmInstallChartTask helmInstallChartTask = project.getTasks()
+                    .create("helmInstallChart", HelmInstallChartTask.class, task -> {
+                        task.getChart().set(CHART.name());
+                        task.getCreateNamespace().set(true);
+                        task.getNamespace().set("simple-test");
+                        task.getRelease().set(RELEASE_NAME);
+                        task.getRepo().set(CHART.repoName());
+                    });
+            assertEquals(RELEASE_NAME, helmInstallChartTask.getRelease().get());
+            helmInstallChartTask.installChart();
+        } finally {
+            suppressExceptions(() -> helmClient.uninstallChart(RELEASE_NAME));
+            suppressExceptions(() -> helmClient.removeRepository(REPOSITORY));
+        }
+    }
+}

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
@@ -109,7 +109,7 @@ class HelmInstallChartTaskTest {
     void testErrorThrownWhenChartNotFound() {
         assertThrows(HelmExecutionException.class, () -> {
             HelmInstallChartTask helmInstallChartTask = project.getTasks()
-                    .create("helmInstallChart", HelmInstallChartTask.class, task -> {
+                    .create("helmInstallNonExistingChartChart", HelmInstallChartTask.class, task -> {
                         task.getChart().set("not-a-chart");
                         task.getCreateNamespace().set(true);
                         task.getNamespace().set("test-failure");

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
@@ -20,6 +20,7 @@ import static com.hedera.fullstack.base.api.util.ExceptionUtils.suppressExceptio
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.hedera.fullstack.helm.client.HelmClient;
+import com.hedera.fullstack.helm.client.HelmExecutionException;
 import com.hedera.fullstack.helm.client.model.Chart;
 import com.hedera.fullstack.helm.client.model.Repository;
 import java.io.File;
@@ -101,5 +102,21 @@ class HelmInstallChartTaskTest {
             suppressExceptions(() -> helmClient.uninstallChart(RELEASE_NAME));
             suppressExceptions(() -> helmClient.removeRepository(REPOSITORY));
         }
+    }
+
+    @Test
+    @DisplayName("test an error is thrown when the chart is not found")
+    void testErrorThrownWhenChartNotFound() {
+        assertThrows(HelmExecutionException.class, () -> {
+            HelmInstallChartTask helmInstallChartTask = project.getTasks()
+                    .create("helmInstallChart", HelmInstallChartTask.class, task -> {
+                        task.getChart().set("not-a-chart");
+                        task.getCreateNamespace().set(true);
+                        task.getNamespace().set("test-failure");
+                        task.getRelease().set("not-a-release");
+                        task.getRepo().set("not-a-repo");
+                    });
+            helmInstallChartTask.installChart();
+        });
     }
 }

--- a/fullstack-gradle-plugin/src/test/java/module-info.java
+++ b/fullstack-gradle-plugin/src/test/java/module-info.java
@@ -1,1 +1,0 @@
-module com.hedera.fullstack.gradle.plugin.test {}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,10 @@
 
 pluginManagement { includeBuild("build-logic") }
 
-plugins { id("com.gradle.enterprise").version("3.13.2") }
+plugins {
+    id("com.gradle.enterprise").version("3.14.1")
+    id("com.hedera.fullstack.settings")
+}
 
 rootProject.name = "full-stack-testing"
 
@@ -45,7 +48,7 @@ include(":fullstack-datasource-api")
 
 include(":fullstack-datasource-core")
 
-include(":fullstack-examples")
+includeBuild("fullstack-examples")
 
 include(":fullstack-gradle-plugin")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,7 +48,8 @@ include(":fullstack-datasource-api")
 
 include(":fullstack-datasource-core")
 
-includeBuild("fullstack-examples")
+// TODO: re-enable once we have a way to run the fullstack-examples without IntelliJ and Sonar issues
+//includeBuild("fullstack-examples")
 
 include(":fullstack-gradle-plugin")
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -48,8 +48,8 @@ include(":fullstack-datasource-api")
 
 include(":fullstack-datasource-core")
 
-// TODO: re-enable once we have a way to run the fullstack-examples without IntelliJ and Sonar issues
-//includeBuild("fullstack-examples")
+// TODO: re-enable once we have a way to run the *-examples without IntelliJ and Sonar issues
+// includeBuild("fullstack-examples")
 
 include(":fullstack-gradle-plugin")
 


### PR DESCRIPTION
## Description

This pull request changes the following:

- settings-plugins
- fullstack-examples becomes a separate gradle project in order to leverage the fullstack-gradle-plugin
- HelmInstallChartTask
- added example usages of HelmInstallChartTask in fullstack-examples project

Notes:
- fullstack-examples now has to be opened as a separate IntelliJ project in order for it to load in IntelliJ
- running fullstack-examples from the command line:
```
cd fullstack-examples
../gradlew clean build
../gradlew spotlessApply
../gradlew helmInstallNginxChart
helm uninstall nginx-release --namespace nginx-ns
```

PR Walkthrough (21 minutes): https://www.loom.com/share/01ec31f227af4b6c8debbdaa6f5faf49?sid=70205d86-fe5c-43db-98e9-cd6b1ec22007
### Related Issues

- Relates to #288 
- Closes #322 
- depends on #365 
- depends on #366 
