### PR TITLE
feat: allow pod-monitor-role to have access to secrets

### DIFF
--- a/charts/hedera-network/templates/rbac/pod-monitor-role.yaml
+++ b/charts/hedera-network/templates/rbac/pod-monitor-role.yaml
@@ -7,6 +7,7 @@ rules:
     resources:
       - pods
       - pods/log
+      - secrets
     verbs:
       - get
       - list


### PR DESCRIPTION
## Description

This pull request changes the following:

- allows pod-monitor-role to have access to secrets

### Related Issues

- Closes #308 
