### PR TITLE
feat: expose prometheus metrics from HAProxy

### DIFF
--- a/charts/hedera-network/templates/services/haproxy-svc.yaml
+++ b/charts/hedera-network/templates/services/haproxy-svc.yaml
@@ -7,6 +7,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: haproxy-{{ $node.name }}-svc
+  labels:
+    fullstack.hedera.com/type: haproxy-svc
+    fullstack.hedera.com/node-name: {{ $node.name }}
+    fullstack.hedera.com/prometheus-endpoint: active
 spec:
   {{- if default $defaults.loadBalancerEnabled $haproxy.loadBalancerEnabled | eq "true" }}
   type: LoadBalancer
@@ -20,6 +24,9 @@ spec:
     - name: tls-grpc-client-port
       port: 50212
       targetPort: 50212
+    - name: prometheus # stats port
+      port: 14567
+      targetPort: 14567
 {{- end }}
 {{- end }}
 

--- a/charts/hedera-network/templates/services/network-node-svc.yaml
+++ b/charts/hedera-network/templates/services/network-node-svc.yaml
@@ -6,7 +6,8 @@ metadata:
   name: network-{{ $nodeConfig.name }}-svc
   labels:
     fullstack.hedera.com/type: network-node-svc
-    fullstack.hedera.com/node-name: {{ $nodeConfig.name }} 
+    fullstack.hedera.com/node-name: {{ $nodeConfig.name }}
+    fullstack.hedera.com/prometheus-endpoint: active
 spec:
   selector:
     app: network-{{ $nodeConfig.name }}

--- a/charts/hedera-network/templates/telemetry/prometheus-svc-monitor.yaml
+++ b/charts/hedera-network/templates/telemetry/prometheus-svc-monitor.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      fullstack.hedera.com/type: network-node-svc
+      fullstack.hedera.com/prometheus-endpoint: active
   endpoints:
     - port: prometheus # must match the prometheus port-name in network-node-svc.yaml
       interval: 10s # ideally it should be higher than the node-metrics-scraper interval set in otel-collector-config.yaml


### PR DESCRIPTION
## Description

This pull request changes the following:

- Expose prometheus metrics from HAProxy
- Allows prometheus service monitor to scrape both network-node and HAProxy metrics based on a specific label `fullstack.hedera.com/prometheus-endpoint: active`
  - The label also allows disabling prometheus service monitor scraping
- Ensures `/stats` (requires login) and `/metrics` endpoints are available for HAProxy

### Related Issues

- Closes #269

### Screenshots
- HAProxy stats: /stats
<img width="1880" alt="Screenshot 2023-09-08 at 12 38 23 PM" src="https://github.com/hashgraph/full-stack-testing/assets/811437/0ca8cde6-2e49-4191-8f3f-4212309cb492">

- HAProxy metrics: /metrics 
<img width="905" alt="Screenshot 2023-09-08 at 12 38 32 PM" src="https://github.com/hashgraph/full-stack-testing/assets/811437/6c9f154f-de44-47fe-a0fe-e1eb8bf9482f">

- Prometheus targets:
<img width="1410" alt="Screenshot 2023-09-08 at 12 39 39 PM" src="https://github.com/hashgraph/full-stack-testing/assets/811437/a5ca85dd-558d-43f2-8752-98ca88094c84">

- Exported HAProxy metrics:
<img width="1709" alt="Screenshot 2023-09-08 at 12 39 55 PM" src="https://github.com/hashgraph/full-stack-testing/assets/811437/0d2d8a27-c457-435a-836e-82d0334f7f1f">
