### PR TITLE
feat: support higher number of nodes with consistent gateway port mapping

### DIFF
--- a/charts/hedera-network/templates/gateway-api/envoy-grpc-web-routes.yaml
+++ b/charts/hedera-network/templates/gateway-api/envoy-grpc-web-routes.yaml
@@ -6,14 +6,14 @@
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: HTTPRoute
 metadata:
-  name: envoy-routes-{{ $node.name }}
+  name: envoy-grpc-web-route-{{ $node.name }}
   namespace: default
   labels:
     fullstack.hedera.com/type: http-route
 spec:
   parentRefs:
     - name: fst
-      sectionName: http-{{ $node.name }}
+      sectionName: grpc-web-{{ $node.name }}
   hostnames:
     - {{ tpl $.Values.gatewayApi.route.hostname (dict "node" $node "Template" $.Template) }}
   rules:

--- a/charts/hedera-network/templates/gateway-api/gateway.yaml
+++ b/charts/hedera-network/templates/gateway-api/gateway.yaml
@@ -36,17 +36,31 @@ spec:
       allowedRoutes:
         kinds:
           - kind: TCPRoute # we use TCPRoute to for GRPC
-    {{- range $index, $node := $.Values.hedera.nodes }}
-    {{- $tcp_port := mul $index 1000 | add 50211 }}
-    {{- $http_port := mul $index 100 | add 8080 }}
-    - name: tcp-{{ $node.name }} # for haproxy or network-node TCPRoute
+    {{- range $index, $node := $.Values.hedera.nodes }} # we assume to have at most 999 nodes in a single cluster
+    {{- $gossip_port   := add $index 51000 }} # node0:51000 ... node999: 51999, points to 50111 port in haproxy or network-node
+    {{- $grpc_port     := add $index 52000 }} # node0:52000 ... node999: 52999, points to 50211 port in haproxy or network-node
+    {{- $grpcs_port    := add $index 53000 }} # node0:53000 ... node999: 53999, points to 50212 port in haproxy or network-node
+    {{- $grpc_web_port := add $index 18000 }} # node0:18000 ... node999: 18999, points to 8080 port in envoy proxy
+    - name: gossip-{{ $node.name }} # for exposing gossip port 50111 from network-node
       protocol: TCP
-      port: {{ $tcp_port }}
+      port: {{ $gossip_port }}
       allowedRoutes:
         kinds:
           - kind: TCPRoute
-    - name: http-{{ $node.name }} # for envoy-proxy HTTPRoute
+    - name: grpc-{{ $node.name }} # for exposing grpc port 50211 from haproxy or network-node
+      protocol: TCP
+      port: {{ $grpc_port }}
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+    - name: grpcs-{{ $node.name }} # for exposing grpc port 50212 from haproxy or network-node
+      protocol: TCP
+      port: {{ $grpcs_port }}
+      allowedRoutes:
+        kinds:
+          - kind: TCPRoute
+    - name: grpc-web-{{ $node.name }} # for exposing grpc-web port 8080 from envoy-proxy
       protocol: HTTP
-      port: {{ $http_port }}
+      port: {{ $grpc_web_port }}
     {{- end }}
 {{- end }}

--- a/charts/hedera-network/templates/gateway-api/haproxy-grpc-routes.yaml
+++ b/charts/hedera-network/templates/gateway-api/haproxy-grpc-routes.yaml
@@ -1,12 +1,12 @@
 {{- range $index, $node := ($.Values.hedera.nodes) }}
 {{- $haproxy := $node.haproxy | default dict -}}
 {{- $defaults := $.Values.defaults.haproxy }}
-{{- if default $defaults.enable $haproxy.enable | eq "false" }}
+{{- if default $defaults.enable $haproxy.enable | eq "true" }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: node-grpc-route-{{ $node.name }}
+  name: haproxy-grpc-route-{{ $node.name }}
   namespace: default
   labels:
     fullstack.hedera.com/type: tcp-route
@@ -14,10 +14,10 @@ metadata:
 spec:
   parentRefs:
     - name: fst
-      sectionName: tcp-{{ $node.name }}
+      sectionName: grpc-{{ $node.name }}
   rules:
     - backendRefs:
-      - name: network-{{ $node.name }}-svc
+      - name: haproxy-{{ $node.name }}-svc
         port: 50211
 {{- end }}
 {{- end }}

--- a/charts/hedera-network/templates/gateway-api/network-node-grpc-routes.yaml
+++ b/charts/hedera-network/templates/gateway-api/network-node-grpc-routes.yaml
@@ -1,12 +1,12 @@
 {{- range $index, $node := ($.Values.hedera.nodes) }}
 {{- $haproxy := $node.haproxy | default dict -}}
 {{- $defaults := $.Values.defaults.haproxy }}
-{{- if default $defaults.enable $haproxy.enable | eq "true" }}
+{{- if default $defaults.enable $haproxy.enable | eq "false" }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: haproxy-grpc-route-{{ $node.name }}
+  name: node-grpc-route-{{ $node.name }}
   namespace: default
   labels:
     fullstack.hedera.com/type: tcp-route
@@ -14,10 +14,10 @@ metadata:
 spec:
   parentRefs:
     - name: fst
-      sectionName: tcp-{{ $node.name }}
+      sectionName: grpc-{{ $node.name }}
   rules:
     - backendRefs:
-      - name: haproxy-{{ $node.name }}-svc
+      - name: network-{{ $node.name }}-svc
         port: 50211
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

This pull request changes the following:

- Support Higher Number of Nodes With Consistent Gateway Port Mapping
```
Gossip ports:   node0: 51000 ... node999: 51999  (Node Port 50111)
GRPC ports:     node0: 52000 ... node999: 52999  (Node Port 50211)
GRPCS ports:    node0: 53000 ... node999: 53999  (Node Port 50212)
GRPC-Web ports: node0: 18000 ... node999: 18999  (Node Port 8080)
```

### Related Issues

- Closes #334 