### PR TITLE
fix: update KeyValuePair.equals to only compare key (not value)

### DIFF
--- a/fullstack-base-api/src/main/java/com/hedera/fullstack/base/api/collections/KeyValuePair.java
+++ b/fullstack-base-api/src/main/java/com/hedera/fullstack/base/api/collections/KeyValuePair.java
@@ -47,7 +47,7 @@ public record KeyValuePair<K, V>(K key, V value) {
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (!(o instanceof KeyValuePair<?, ?> that)) return false;
-        return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+        return Objects.equals(key, that.key);
     }
 
     @Override

--- a/fullstack-base-api/src/test/java/com/hedera/fullstack/base/api/test/collections/KeyValuePairTest.java
+++ b/fullstack-base-api/src/test/java/com/hedera/fullstack/base/api/test/collections/KeyValuePairTest.java
@@ -28,7 +28,7 @@ public class KeyValuePairTest {
     void testKeyValuePair() {
         KeyValuePair<String, String> kvp1 = new KeyValuePair<>("key", "value");
         KeyValuePair<String, String> kvp1v2 = new KeyValuePair<>("key", "value2");
-        assertThat(kvp1).isNotEqualTo(kvp1v2);
+        assertThat(kvp1).isEqualTo(kvp1v2);
         assertThat(kvp1.hashCode()).isEqualTo(kvp1v2.hashCode());
     }
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- updates the KeyValuePair.equals() method to only compare key (not value)

### Related Issues

- Closes #346 
