### PR TITLE
fix: uninstall envoy-gateway should also remove gateway-system namespace that it created

### DIFF
--- a/dev/scripts/gateway.sh
+++ b/dev/scripts/gateway.sh
@@ -109,6 +109,7 @@ function destroy_envoy_gateway_api() {
   if [[ "${helm_chart}" ]]; then
     helm uninstall envoy-gateway -n envoy-gateway-system
     kubectl delete ns envoy-gateway-system
+    kubectl delete ns gateway-system
   fi
 
   uninstall_crd "gateway.networking.k8s.io"


### PR DESCRIPTION

## Description

This pull request changes the following:

- updated `destroy-gateway-api` command to remove `gateway-system` namespace as well

### Related Issues

- Closes #349 
