### PR TITLE
fix: install GatewayClass separately as a shared resource for all namespaces

### DIFF
--- a/charts/hedera-network/templates/gateway-api/gateway.yaml
+++ b/charts/hedera-network/templates/gateway-api/gateway.yaml
@@ -1,16 +1,4 @@
-{{- if $.Values.gatewayApi.gatewayClass.enable | eq "true" }}
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: GatewayClass
-metadata:
-  name: {{ $.Values.gatewayApi.gatewayClass.name }}
-  namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
-  labels:
-    fullstack.hedera.com/type: gateway-class
-spec:
-  controllerName: {{ $.Values.gatewayApi.gatewayClass.controllerName }}
-{{- end }}
 {{- if $.Values.gatewayApi.gateway.enable | eq "true" }}
----
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway
 metadata:

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -36,10 +36,7 @@ tester:
 # gateway-api configuration
 gatewayApi:
   gatewayClass:
-    name: "fst"
-    enable: "true"
-    controllerName: "gateway.envoyproxy.io/gatewayclass-controller"
-#    controllerName: "haproxy-ingress.github.io/controller"
+    name: "fst-gateway-class"
   gateway:
     name: "fst"
     enable: "true"

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -59,20 +59,21 @@ uninstall-chart:
 update-helm-dependencies:
 	helm dependency update ../charts/hedera-network
 
+.PHONY: deploy-common
+deploy-common: update-helm-dependencies deploy-gateway-api deploy-prometheus-operator deploy-minio-operator-if-required
+
+.PHONY: destroy-common
+destroy-common: destroy-gateway-api destroy-prometheus-operator undeploy-minio-operator
+
 .PHONY: deploy-chart
 deploy-chart:
-	$(MAKE) update-helm-dependencies
-	$(MAKE) deploy-minio-operator-if-required
-	$(MAKE)	deploy-prometheus-operator
-	$(MAKE) deploy-gateway-api
+	$(MAKE) deploy-common
 	$(MAKE) install-chart
 
 .PHONY: destroy-chart
 destroy-chart:
 	-$(MAKE) uninstall-chart
-	-$(MAKE) destroy-gateway-api
-	-$(MAKE) destroy-prometheus-operator
-	-$(MAKE) undeploy-minio-operator
+	-$(MAKE) destroy-common
 
 .PHONY: deploy-network
 deploy-network: deploy-chart

--- a/dev/common-resources/fst-gateway.yaml
+++ b/dev/common-resources/fst-gateway.yaml
@@ -1,0 +1,9 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: GatewayClass
+metadata:
+  name: fst-gateway-class
+  labels:
+    fullstack.hedera.com/type: gateway-class
+spec:
+  controllerName: "gateway.envoyproxy.io/gatewayclass-controller"
+  #controllerName: "haproxy-ingress.github.io/controller"

--- a/dev/scripts/env.sh
+++ b/dev/scripts/env.sh
@@ -8,6 +8,8 @@ readonly CHART_DIR="${SCRIPT_DIR}/../../charts/hedera-network"
 
 
 # telemetry related env variables
+readonly COMMON_RESOURCES="${SCRIPT_DIR}/../common-resources"
+readonly GATEWAY_CLASS_NAME="fst-gateway-class"
 readonly GATEWAY_API_DIR="${SCRIPT_DIR}/../gateway-api"
 readonly TELEMETRY_DIR="${SCRIPT_DIR}/../telemetry"
 readonly PROMETHEUS_DIR="${TELEMETRY_DIR}/prometheus"

--- a/dev/scripts/gateway.sh
+++ b/dev/scripts/gateway.sh
@@ -67,6 +67,33 @@ function deploy_gateway_api_crd() {
 	fi
 }
 
+function deploy_fst_gateway_class() {
+  echo ""
+	echo "Installing FST Gateway Class: ${GATEWAY_CLASS_NAME}"
+  echo "-----------------------------------------------------------------------------------------------------"
+  local fst_gateway_class_type=$(kubectl get gc "${GATEWAY_CLASS_NAME}" -o jsonpath='{.metadata.labels.fullstack\.hedera\.com\/type}')
+  if [[ ! "${fst_gateway_class_type}" = "gateway-class" ]]; then
+    kubectl create -f "${COMMON_RESOURCES}/fst-gateway.yaml"
+    kubectl wait --for=condition=Accepted gc "${GATEWAY_CLASS_NAME}" --timeout=300s
+  else
+    echo "FST Gateway Class '${GATEWAY_CLASS_NAME}' is already installed"
+    echo ""
+  fi
+}
+
+function destroy_fst_gateway_class() {
+  echo ""
+	echo "Uninstalling FST Gateway Class: ${GATEWAY_CLASS_NAME}"
+  echo "-----------------------------------------------------------------------------------------------------"
+  local fst_gateway_class_type=$(kubectl get gc "${GATEWAY_CLASS_NAME}" -o jsonpath='{.metadata.labels.fullstack\.hedera\.com\/type}')
+  if [[ ! "${fst_gateway_class_type}" = "gateway-class" ]]; then
+    kubectl delete -f "${COMMON_RESOURCES}/fst-gateway.yaml"
+    sleep 2s
+  fi
+  echo "FST Gateway Class '${GATEWAY_CLASS_NAME}' is uninstalled"
+  echo ""
+}
+
 function deploy_envoy_gateway_api() {
   echo ""
 	echo "Installing Envoy Gateway API"
@@ -79,22 +106,27 @@ function deploy_envoy_gateway_api() {
     echo "Envoy Gateway API is already installed"
     echo ""
   fi
+
+  deploy_fst_gateway_class
+
+  get_gateway_status
 }
 
 function get_gateway_status() {
   echo ""
   helm list --all-namespaces | grep envoy-gateway
-  echo "-----------------------------------------------------------------------------------------------------"
+  echo "-----------------------Gateway CRDs------------------------------------------------------------------------------"
   kubectl get crd
-  echo "-----------------------------------------------------------------------------------------------------"
+  echo "-----------------------Gateway Class------------------------------------------------------------------------------"
   kubectl get gatewayclass
-  echo "-----------------------------------------------------------------------------------------------------"
+  echo "-----------------------Gateway------------------------------------------------------------------------------"
   kubectl get gateway
-  echo "-----------------------------------------------------------------------------------------------------"
+  echo "-----------------------HTTPRoute------------------------------------------------------------------------------"
   kubectl get httproute
-  echo "-----------------------------------------------------------------------------------------------------"
+  echo "-----------------------GRPCRoute------------------------------------------------------------------------------"
   kubectl get grpcroute
-  echo "-----------------------------------------------------------------------------------------------------"
+  echo "-----------------------TCPRoute------------------------------------------------------------------------------"
+  kubectl get tcproute
 }
 
 function destroy_envoy_gateway_api() {
@@ -102,6 +134,8 @@ function destroy_envoy_gateway_api() {
 	echo "Uninstalling Envoy Gateway API"
   echo "-----------------------------------------------------------------------------------------------------"
   get_gateway_status
+
+  destroy_fst_gateway_class
 
   # Uninstall helm chart
   local helm_chart=$(helm list --all-namespaces | grep envoy-gateway)


### PR DESCRIPTION
## Description

This pull request changes the following:

- install FST gateway class separately as a shared resource for all namespaces
- The setup script execution is made idempotent

### Related Issues

- Closes #358 
- Partially Resolves: #353 
