### PR TITLE
feat: upgrade to org.gradlex:java-module-dependencies:1.4.1

### DIFF
--- a/build-logic/project-plugins/build.gradle.kts
+++ b/build-logic/project-plugins/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
     implementation("com.autonomousapps:dependency-analysis-gradle-plugin:1.20.0")
     implementation("org.gradlex:extra-java-module-info:1.4")
     implementation("org.gradlex:java-ecosystem-capabilities:1.1")
-    implementation("org.gradlex:java-module-dependencies:1.3")
+    implementation("org.gradlex:java-module-dependencies:1.4.1")
 
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.18.0")
     implementation("org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:4.0.0.2929")


### PR DESCRIPTION
## Description

This pull request changes the following:

- upgrade to org.gradlex:java-module-dependencies:1.4.1

### Related Issues

- Closes #364 
- relates to #304 
