### PR TITLE
feat: enhance Helm Install to support multiple set and values parameters

### DIFF
--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecution.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecution.java
@@ -218,30 +218,26 @@ public final class HelmExecution {
         }
 
         if (exitCode() != 0) {
-            throw new HelmExecutionException(exitCode());
+            throw new HelmExecutionException(
+                    exitCode(),
+                    StreamUtils.streamToString(suppressExceptions(this::standardOutput)),
+                    StreamUtils.streamToString(suppressExceptions(this::standardError)));
         }
-
         final String standardOutput = StreamUtils.streamToString(suppressExceptions(this::standardOutput));
         final String standardError = StreamUtils.streamToString(suppressExceptions(this::standardError));
 
-        LOGGER.atDebug()
-                .setMessage(
-                        "ResponseAs exiting with exitCode: {}\n\tResponseClass: {}\n\tstandardOutput: {}\n\tstandardError: {}")
-                .addArgument(this::exitCode)
-                .addArgument(responseClass.getName())
-                .addArgument(standardOutput)
-                .addArgument(standardError)
-                .log();
+        LOGGER.debug(
+                "ResponseAs exiting with exitCode: {}%n\tResponseClass: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                exitCode(), responseClass.getName(), standardOutput, standardError);
 
         try {
             return OBJECT_MAPPER.readValue(standardOutput, responseClass);
         } catch (final Exception e) {
-            LOGGER.atWarn()
-                    .setMessage("ResponseAs failed to deserialize response into class: {}\n\tresponse: {}")
-                    .addArgument(responseClass.getName())
-                    .addArgument(standardOutput)
-                    .setCause(e)
-                    .log();
+            LOGGER.warn(
+                    String.format(
+                            "ResponseAs failed to deserialize response into class: %s%n\tresponse: %s",
+                            responseClass.getName(), standardOutput),
+                    e);
 
             throw new HelmParserException(String.format(MSG_DESERIALIZATION_ERROR, responseClass.getName()), e);
         }
@@ -291,14 +287,9 @@ public final class HelmExecution {
         final String standardOutput = StreamUtils.streamToString(suppressExceptions(this::standardOutput));
         final String standardError = StreamUtils.streamToString(suppressExceptions(this::standardError));
 
-        LOGGER.atDebug()
-                .setMessage(
-                        "ResponseAsList exiting with exitCode: {}\n\tResponseClass: {}\n\tstandardOutput: {}\n\tstandardError: {}")
-                .addArgument(this::exitCode)
-                .addArgument(responseClass.getName())
-                .addArgument(standardOutput)
-                .addArgument(standardError)
-                .log();
+        LOGGER.debug(
+                "ResponseAsList exiting with exitCode: {}%n\tResponseClass: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                exitCode(), responseClass.getName(), standardOutput, standardError);
 
         try {
             return OBJECT_MAPPER
@@ -306,13 +297,11 @@ public final class HelmExecution {
                     .<T>readValues(standardOutput)
                     .readAll();
         } catch (final Exception e) {
-            LOGGER.atWarn()
-                    .setMessage(
-                            "ResponseAsList failed to deserialize the output into a list of the specified class: {}\n\tresponse: {}")
-                    .addArgument(responseClass.getName())
-                    .addArgument(standardOutput)
-                    .setCause(e)
-                    .log();
+            LOGGER.warn(
+                    String.format(
+                            "ResponseAsList failed to deserialize the output into a list of the specified class: %s%n\tresponse: %s",
+                            responseClass.getName(), standardOutput),
+                    e);
 
             throw new HelmParserException(String.format(MSG_LIST_DESERIALIZATION_ERROR, responseClass.getName()), e);
         }
@@ -349,20 +338,14 @@ public final class HelmExecution {
         final String standardOutput = StreamUtils.streamToString(suppressExceptions(this::standardOutput));
         final String standardError = StreamUtils.streamToString(suppressExceptions(this::standardError));
 
-        LOGGER.atDebug()
-                .setMessage("Call exiting with exitCode: {}\n\tstandardOutput: {}\n\tstandardError: {}")
-                .addArgument(this::exitCode)
-                .addArgument(standardOutput)
-                .addArgument(standardError)
-                .log();
+        LOGGER.debug(
+                "Call exiting with exitCode: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                exitCode(), standardOutput, standardError);
 
         if (exitCode() != 0) {
-            LOGGER.atWarn()
-                    .setMessage("Call failed with exitCode: {}\n\tstandardOutput: {}\n\tstandardError: {}")
-                    .addArgument(this::exitCode)
-                    .addArgument(standardOutput)
-                    .addArgument(standardError)
-                    .log();
+            LOGGER.warn(
+                    "Call failed with exitCode: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                    exitCode(), standardOutput, standardError);
 
             throw new HelmExecutionException(exitCode(), standardError, standardOutput);
         }

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecution.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecution.java
@@ -228,7 +228,10 @@ public final class HelmExecution {
 
         LOGGER.debug(
                 "ResponseAs exiting with exitCode: {}TODO\n\tResponseClass: {}\n\tstandardOutput: {}\n\tstandardError: {}",
-                exitCode(), responseClass.getName(), standardOutput, standardError);
+                exitCode(),
+                responseClass.getName(),
+                standardOutput,
+                standardError);
 
         try {
             return OBJECT_MAPPER.readValue(standardOutput, responseClass);
@@ -289,7 +292,10 @@ public final class HelmExecution {
 
         LOGGER.debug(
                 "ResponseAsList exiting with exitCode: {}\n\tResponseClass: {}\n\tstandardOutput: {}\n\tstandardError: {}",
-                exitCode(), responseClass.getName(), standardOutput, standardError);
+                exitCode(),
+                responseClass.getName(),
+                standardOutput,
+                standardError);
 
         try {
             return OBJECT_MAPPER
@@ -340,12 +346,16 @@ public final class HelmExecution {
 
         LOGGER.debug(
                 "Call exiting with exitCode: {}\n\tstandardOutput: {}\n\tstandardError: {}",
-                exitCode(), standardOutput, standardError);
+                exitCode(),
+                standardOutput,
+                standardError);
 
         if (exitCode() != 0) {
             LOGGER.warn(
                     "Call failed with exitCode: {}\n\tstandardOutput: {}\n\tstandardError: {}",
-                    exitCode(), standardOutput, standardError);
+                    exitCode(),
+                    standardOutput,
+                    standardError);
 
             throw new HelmExecutionException(exitCode(), standardError, standardOutput);
         }

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecution.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecution.java
@@ -227,7 +227,7 @@ public final class HelmExecution {
         final String standardError = StreamUtils.streamToString(suppressExceptions(this::standardError));
 
         LOGGER.debug(
-                "ResponseAs exiting with exitCode: {}%n\tResponseClass: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                "ResponseAs exiting with exitCode: {}TODO\n\tResponseClass: {}\n\tstandardOutput: {}\n\tstandardError: {}",
                 exitCode(), responseClass.getName(), standardOutput, standardError);
 
         try {
@@ -288,7 +288,7 @@ public final class HelmExecution {
         final String standardError = StreamUtils.streamToString(suppressExceptions(this::standardError));
 
         LOGGER.debug(
-                "ResponseAsList exiting with exitCode: {}%n\tResponseClass: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                "ResponseAsList exiting with exitCode: {}\n\tResponseClass: {}\n\tstandardOutput: {}\n\tstandardError: {}",
                 exitCode(), responseClass.getName(), standardOutput, standardError);
 
         try {
@@ -339,12 +339,12 @@ public final class HelmExecution {
         final String standardError = StreamUtils.streamToString(suppressExceptions(this::standardError));
 
         LOGGER.debug(
-                "Call exiting with exitCode: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                "Call exiting with exitCode: {}\n\tstandardOutput: {}\n\tstandardError: {}",
                 exitCode(), standardOutput, standardError);
 
         if (exitCode() != 0) {
             LOGGER.warn(
-                    "Call failed with exitCode: {}%n\tstandardOutput: {}%n\tstandardError: {}",
+                    "Call failed with exitCode: {}\n\tstandardOutput: {}\n\tstandardError: {}",
                     exitCode(), standardOutput, standardError);
 
             throw new HelmExecutionException(exitCode(), standardError, standardOutput);

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecutionBuilder.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecutionBuilder.java
@@ -48,9 +48,9 @@ public final class HelmExecutionBuilder {
     private final HashMap<String, String> arguments;
 
     /**
-     * The list of key value pairs where the value is a list of values for the given key.
+     * The list of options and a list of their one or more values.
      */
-    private final List<KeyValuePair<String, List<String>>> keyListOfValuesPairList;
+    private final List<KeyValuePair<String, List<String>>> optionsWithMultipleValues;
 
     /**
      * The flags to be passed to the helm command.
@@ -81,7 +81,7 @@ public final class HelmExecutionBuilder {
         this.helmExecutable = Objects.requireNonNull(helmExecutable, "helmExecutable must not be null");
         this.subcommands = new ArrayList<>();
         this.arguments = new HashMap<>();
-        this.keyListOfValuesPairList = new ArrayList<>();
+        this.optionsWithMultipleValues = new ArrayList<>();
         this.positionals = new ArrayList<>();
         this.flags = new ArrayList<>();
         this.environmentVariables = new HashMap<>();
@@ -120,18 +120,18 @@ public final class HelmExecutionBuilder {
     }
 
     /**
-     * Adds a key with a provided list of values to the helm command.  This is used for options that have can have
-     * multiple values for a single key.  (e.g. --set and --values)
+     * Adds an option with a provided list of values to the helm command.  This is used for options that have can have
+     * multiple values for a single option.  (e.g. --set and --values)
      *
-     * @param name  the key for the key/value pair.
-     * @param value the list of values for the given key.
+     * @param name  the name of the option.
+     * @param value the list of values for the given option.
      * @return this builder.
      * @throws NullPointerException if either {@code name} or {@code value} is {@code null}.
      */
-    public HelmExecutionBuilder keyListOfValuesPair(final String name, final List<String> value) {
+    public HelmExecutionBuilder optionsWithMultipleValues(final String name, final List<String> value) {
         Objects.requireNonNull(name, NAME_MUST_NOT_BE_NULL);
         Objects.requireNonNull(value, VALUE_MUST_NOT_BE_NULL);
-        this.keyListOfValuesPairList.add(new KeyValuePair<>(name, value));
+        this.optionsWithMultipleValues.add(new KeyValuePair<>(name, value));
         return this;
     }
 
@@ -225,7 +225,7 @@ public final class HelmExecutionBuilder {
             command.add(value);
         });
 
-        keyListOfValuesPairList.forEach(entry -> entry.value().forEach(value -> {
+        optionsWithMultipleValues.forEach(entry -> entry.value().forEach(value -> {
             command.add(String.format("--%s", entry.key()));
             command.add(value);
         }));

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecutionBuilder.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/execution/HelmExecutionBuilder.java
@@ -86,9 +86,10 @@ public final class HelmExecutionBuilder {
         this.flags = new ArrayList<>();
         this.environmentVariables = new HashMap<>();
 
-        String workingDirectory = System.getenv("PWD");
-        this.workingDirectory =
-                workingDirectory == null ? this.helmExecutable.getParent() : new File(workingDirectory).toPath();
+        String workingDirectoryString = System.getenv("PWD");
+        this.workingDirectory = workingDirectoryString == null
+                ? this.helmExecutable.getParent()
+                : new File(workingDirectoryString).toPath();
     }
 
     /**
@@ -132,6 +133,7 @@ public final class HelmExecutionBuilder {
         this.argumentsSet.add(new KeyValuePair<>(name, value));
         return this;
     }
+
     /**
      * Adds a positional argument to the helm command.
      *
@@ -161,13 +163,13 @@ public final class HelmExecutionBuilder {
     }
 
     /**
-     * Sets the working directory for the helm process.
+     * Sets the Path of the working directory for the helm process.
      *
-     * @param workingDirectory the working directory.
+     * @param workingDirectoryPath the Path of the working directory.
      * @return this builder.
      */
-    public HelmExecutionBuilder workingDirectory(final Path workingDirectory) {
-        this.workingDirectory = Objects.requireNonNull(workingDirectory, "workingDirectory must not be null");
+    public HelmExecutionBuilder workingDirectory(final Path workingDirectoryPath) {
+        this.workingDirectory = Objects.requireNonNull(workingDirectoryPath, "workingDirectoryPath must not be null");
         return this;
     }
 
@@ -230,7 +232,10 @@ public final class HelmExecutionBuilder {
         command.addAll(positionals);
 
         String[] commandArray = command.toArray(new String[0]);
-        LOGGER.debug("Helm command: {}", String.join(" ", Arrays.copyOfRange(commandArray, 1, commandArray.length)));
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
+                    "Helm command: {}", String.join(" ", Arrays.copyOfRange(commandArray, 1, commandArray.length)));
+        }
 
         return commandArray;
     }

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/Chart.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/Chart.java
@@ -16,19 +16,12 @@
 
 package com.hedera.fullstack.helm.client.model;
 
-import java.util.Objects;
-
 /**
  * Represents a chart and is used to interact with the Helm install and uninstall commands.
  * @param repoName the name of repository which contains the Helm chart.
  * @param name the name of the Helm chart.
  */
 public record Chart(String name, String repoName) {
-
-    public Chart {
-        Objects.requireNonNull(repoName, "repoName must not be null");
-    }
-
     public Chart(String name) {
         this(name, null);
     }

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptions.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptions.java
@@ -18,7 +18,7 @@ package com.hedera.fullstack.helm.client.model.install;
 
 import com.hedera.fullstack.helm.client.execution.HelmExecutionBuilder;
 import com.hedera.fullstack.helm.client.model.Options;
-import java.util.Set;
+import java.util.List;
 
 /**
  * The options to be supplied to the helm install command.
@@ -56,11 +56,11 @@ public record InstallChartOptions(
         boolean passCredentials,
         String password,
         String repo,
-        Set<String> set,
+        List<String> set,
         boolean skipCrds,
         String timeout,
         String username,
-        Set<String> values,
+        List<String> values,
         boolean verify,
         String version,
         boolean waitFor)
@@ -98,7 +98,7 @@ public record InstallChartOptions(
         }
 
         if (set() != null) {
-            builder.argumentSet("set", set());
+            builder.keyListOfValuesPair("set", set());
         }
 
         if (timeout() != null) {
@@ -110,7 +110,7 @@ public record InstallChartOptions(
         }
 
         if (values() != null) {
-            builder.argumentSet("values", values());
+            builder.keyListOfValuesPair("values", values());
         }
 
         if (version() != null) {

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptions.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptions.java
@@ -98,7 +98,7 @@ public record InstallChartOptions(
         }
 
         if (set() != null) {
-            builder.keyListOfValuesPair("set", set());
+            builder.optionsWithMultipleValues("set", set());
         }
 
         if (timeout() != null) {
@@ -110,7 +110,7 @@ public record InstallChartOptions(
         }
 
         if (values() != null) {
-            builder.keyListOfValuesPair("values", values());
+            builder.optionsWithMultipleValues("values", values());
         }
 
         if (version() != null) {

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptions.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptions.java
@@ -18,6 +18,7 @@ package com.hedera.fullstack.helm.client.model.install;
 
 import com.hedera.fullstack.helm.client.execution.HelmExecutionBuilder;
 import com.hedera.fullstack.helm.client.model.Options;
+import java.util.Set;
 
 /**
  * The options to be supplied to the helm install command.
@@ -32,6 +33,7 @@ import com.hedera.fullstack.helm.client.model.Options;
  * @param passCredentials  - pass credentials to all domains.
  * @param password         - chart repository password where to locate the requested chart.
  * @param repo             - chart repository url where to locate the requested chart.
+ * @param set              - set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
  * @param skipCrds         - if set, no CRDs will be installed. By default, CRDs are installed if not already present.
  * @param timeout          - time to wait for any individual Kubernetes operation (like Jobs for hooks) (default 5m0s).
  * @param username         - chart repository username where to locate the requested chart.
@@ -54,10 +56,11 @@ public record InstallChartOptions(
         boolean passCredentials,
         String password,
         String repo,
+        Set<String> set,
         boolean skipCrds,
         String timeout,
         String username,
-        String values,
+        Set<String> values,
         boolean verify,
         String version,
         boolean waitFor)
@@ -94,6 +97,10 @@ public record InstallChartOptions(
             builder.argument("repo", repo());
         }
 
+        if (set() != null) {
+            builder.argumentSet("set", set());
+        }
+
         if (timeout() != null) {
             builder.argument("timeout", timeout());
         }
@@ -103,7 +110,7 @@ public record InstallChartOptions(
         }
 
         if (values() != null) {
-            builder.argument("values", values());
+            builder.argumentSet("values", values());
         }
 
         if (version() != null) {

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptionsBuilder.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptionsBuilder.java
@@ -16,7 +16,7 @@
 
 package com.hedera.fullstack.helm.client.model.install;
 
-import java.util.Set;
+import java.util.List;
 
 /**
  * The builder for the {@link InstallChartOptions}.
@@ -31,11 +31,11 @@ public final class InstallChartOptionsBuilder {
     private boolean passCredentials;
     private String password;
     private String repo;
-    private Set<String> set;
+    private List<String> set;
     private boolean skipCrds;
     private String timeout;
     private String username;
-    private Set<String> values;
+    private List<String> values;
     private boolean verify;
     private String version;
     private boolean waitFor;
@@ -158,7 +158,7 @@ public final class InstallChartOptionsBuilder {
      * @param valueOverride set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
      * @return the current InstallChartOptionsBuilder.
      */
-    public InstallChartOptionsBuilder set(Set<String> valueOverride) {
+    public InstallChartOptionsBuilder set(List<String> valueOverride) {
         this.set = valueOverride;
         return this;
     }
@@ -202,7 +202,7 @@ public final class InstallChartOptionsBuilder {
      * @param values specify values in a YAML file or a URL (can specify multiple).
      * @return the current InstallChartOptionsBuilder.
      */
-    public InstallChartOptionsBuilder values(Set<String> values) {
+    public InstallChartOptionsBuilder values(List<String> values) {
         this.values = values;
         return this;
     }

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptionsBuilder.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/model/install/InstallChartOptionsBuilder.java
@@ -16,6 +16,8 @@
 
 package com.hedera.fullstack.helm.client.model.install;
 
+import java.util.Set;
+
 /**
  * The builder for the {@link InstallChartOptions}.
  */
@@ -29,10 +31,11 @@ public final class InstallChartOptionsBuilder {
     private boolean passCredentials;
     private String password;
     private String repo;
+    private Set<String> set;
     private boolean skipCrds;
     private String timeout;
     private String username;
-    private String values;
+    private Set<String> values;
     private boolean verify;
     private String version;
     private boolean waitFor;
@@ -150,6 +153,17 @@ public final class InstallChartOptionsBuilder {
     }
 
     /**
+     * set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+     *
+     * @param valueOverride set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)
+     * @return the current InstallChartOptionsBuilder.
+     */
+    public InstallChartOptionsBuilder set(Set<String> valueOverride) {
+        this.set = valueOverride;
+        return this;
+    }
+
+    /**
      * if set, no CRDs will be installed. By default, CRDs are installed if not already present.
      *
      * @param skipCrds if set, no CRDs will be installed. By default, CRDs are installed if not already present.
@@ -188,7 +202,7 @@ public final class InstallChartOptionsBuilder {
      * @param values specify values in a YAML file or a URL (can specify multiple).
      * @return the current InstallChartOptionsBuilder.
      */
-    public InstallChartOptionsBuilder values(String values) {
+    public InstallChartOptionsBuilder values(Set<String> values) {
         this.values = values;
         return this;
     }
@@ -247,6 +261,7 @@ public final class InstallChartOptionsBuilder {
                 passCredentials,
                 password,
                 repo,
+                set,
                 skipCrds,
                 timeout,
                 username,

--- a/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/resource/HelmSoftwareLoader.java
+++ b/fullstack-helm-client/src/main/java/com/hedera/fullstack/helm/client/resource/HelmSoftwareLoader.java
@@ -63,9 +63,10 @@ public final class HelmSoftwareLoader {
      * Unpacks the Helm executable contained in the JAR file into a temporary directory.
      *
      * @return the path to the Helm executable.
-     * @throws HelmConfigurationException if the Helm executable cannot be unpacked or the
-     *                                    operating system/architecture combination is not supported.
-     * @implNote This method expects the executable to be present at the following location in the JAR file: {@code /software/<os>/<arch>/helm}.
+     * @throws HelmConfigurationException if the Helm executable cannot be unpacked or the operating system/architecture
+     *                                    combination is not supported.
+     * @implNote This method expects the executable to be present at the following location in the JAR file:
+     * {@code /software/<os>/<arch>/helm}.
      */
     public static Path installSupportedVersion() {
         try {
@@ -86,12 +87,11 @@ public final class HelmSoftwareLoader {
                 pathBuilder.append(".exe");
             }
 
-            LOGGER.atDebug()
-                    .setMessage("Loading Helm executable from JAR file.  [os={}, arch={}, path={}]")
-                    .addArgument(os.name())
-                    .addArgument(arch.name())
-                    .addArgument(pathBuilder.toString())
-                    .log();
+            LOGGER.debug(
+                    "Loading Helm executable from JAR file.  [os={}, arch={}, path={}]",
+                    os.name(),
+                    arch.name(),
+                    pathBuilder);
 
             return RESOURCE_LOADER.load(pathBuilder.toString());
         } catch (IOException | SecurityException | IllegalStateException e) {

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.fullstack.helm.client.test.execution;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.fullstack.helm.client.execution.HelmExecutionBuilder;
+import java.io.File;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class HelmExecutionBuilderTest {
+    @Test
+    @DisplayName("Test argumentSet null checks")
+    void testArgumentSetNullChecks() {
+        HelmExecutionBuilder builder = new HelmExecutionBuilder(new File(".").toPath());
+        assertThrows(NullPointerException.class, () -> {
+            builder.argumentSet(null, null);
+        });
+        assertThrows(NullPointerException.class, () -> {
+            builder.argumentSet("test string", null);
+        });
+    }
+
+    @Test
+    @DisplayName("Test environmentVariable null checks")
+    void testEnvironmentVariableNullChecks() {
+        HelmExecutionBuilder builder = new HelmExecutionBuilder(new File(".").toPath());
+        assertThrows(NullPointerException.class, () -> {
+            builder.environmentVariable(null, null);
+        });
+        assertThrows(NullPointerException.class, () -> {
+            builder.environmentVariable("test string", null);
+        });
+    }
+
+    @Test
+    @DisplayName("Test workingDirectory null checks")
+    void testWorkingDirectoryNullChecks() {
+        HelmExecutionBuilder builder = new HelmExecutionBuilder(new File(".").toPath());
+        assertThrows(NullPointerException.class, () -> {
+            builder.workingDirectory(null);
+        });
+    }
+}

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.api.Test;
 
 class HelmExecutionBuilderTest {
     @Test
-    @DisplayName("Test argumentSet null checks")
-    void testArgumentSetNullChecks() {
+    @DisplayName("Test keyListOfValuesPair null checks")
+    void testKeyListOfValuesPairNullChecks() {
         HelmExecutionBuilder builder = new HelmExecutionBuilder(new File(".").toPath());
         assertThrows(NullPointerException.class, () -> {
-            builder.argumentSet(null, null);
+            builder.keyListOfValuesPair(null, null);
         });
         assertThrows(NullPointerException.class, () -> {
-            builder.argumentSet("test string", null);
+            builder.keyListOfValuesPair("test string", null);
         });
     }
 

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
@@ -25,14 +25,14 @@ import org.junit.jupiter.api.Test;
 
 class HelmExecutionBuilderTest {
     @Test
-    @DisplayName("Test keyListOfValuesPair null checks")
-    void testKeyListOfValuesPairNullChecks() {
+    @DisplayName("Test optionsWithMultipleValues null checks")
+    void testOptionsWithMultipleValuesNullChecks() {
         HelmExecutionBuilder builder = new HelmExecutionBuilder(new File(".").toPath());
         assertThrows(NullPointerException.class, () -> {
-            builder.keyListOfValuesPair(null, null);
+            builder.optionsWithMultipleValues(null, null);
         });
         assertThrows(NullPointerException.class, () -> {
-            builder.keyListOfValuesPair("test string", null);
+            builder.optionsWithMultipleValues("test string", null);
         });
     }
 

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/execution/HelmExecutionBuilderTest.java
@@ -23,7 +23,7 @@ import java.io.File;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class HelmExecutionBuilderTest {
+class HelmExecutionBuilderTest {
     @Test
     @DisplayName("Test argumentSet null checks")
     void testArgumentSetNullChecks() {

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/model/InstallChartOptionsBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/model/InstallChartOptionsBuilderTest.java
@@ -17,12 +17,24 @@
 package com.hedera.fullstack.helm.client.test.model;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import com.hedera.fullstack.helm.client.execution.HelmExecutionBuilder;
 import com.hedera.fullstack.helm.client.model.install.InstallChartOptions;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class InstallChartOptionsBuilderTest {
+    @Mock
+    private HelmExecutionBuilder builderMock;
 
     @Test
     @DisplayName("Test InstallChartOptionsBuilder")
@@ -37,10 +49,11 @@ class InstallChartOptionsBuilderTest {
                 .passCredentials(true)
                 .password("password")
                 .repo("repo")
+                .set(Set.of("set", "livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt]"))
                 .skipCrds(true)
                 .timeout("timeout")
                 .username("username")
-                .values("values")
+                .values(Set.of("values1", "values2"))
                 .verify(true)
                 .version("version")
                 .waitFor(true)
@@ -55,12 +68,19 @@ class InstallChartOptionsBuilderTest {
         assertTrue(options.passCredentials());
         assertEquals("password", options.password());
         assertEquals("repo", options.repo());
+        assertTrue(options.set().stream().anyMatch("livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt]"::equals));
+        assertTrue(options.set().stream().anyMatch("set"::equals));
         assertTrue(options.skipCrds());
         assertEquals("timeout", options.timeout());
         assertEquals("username", options.username());
-        assertEquals("values", options.values());
+        assertTrue(options.values().stream().anyMatch("values1"::equals));
+        assertTrue(options.values().stream().anyMatch("values2"::equals));
         assertTrue(options.verify());
         assertEquals("version", options.version());
         assertTrue(options.waitFor());
+
+        options.apply(builderMock);
+
+        verify(builderMock, times(2)).argumentSet(anyString(), anySet());
     }
 }

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/model/InstallChartOptionsBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/model/InstallChartOptionsBuilderTest.java
@@ -17,14 +17,14 @@
 package com.hedera.fullstack.helm.client.test.model;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.fullstack.helm.client.execution.HelmExecutionBuilder;
 import com.hedera.fullstack.helm.client.model.install.InstallChartOptions;
-import java.util.Set;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,11 +49,11 @@ class InstallChartOptionsBuilderTest {
                 .passCredentials(true)
                 .password("password")
                 .repo("repo")
-                .set(Set.of("set", "livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt]"))
+                .set(List.of("set", "livenessProbe.exec.command=[cat,docroot/CHANGELOG.txt]"))
                 .skipCrds(true)
                 .timeout("timeout")
                 .username("username")
-                .values(Set.of("values1", "values2"))
+                .values(List.of("values1", "values2"))
                 .verify(true)
                 .version("version")
                 .waitFor(true)
@@ -81,6 +81,6 @@ class InstallChartOptionsBuilderTest {
 
         options.apply(builderMock);
 
-        verify(builderMock, times(2)).argumentSet(anyString(), anySet());
+        verify(builderMock, times(2)).keyListOfValuesPair(anyString(), anyList());
     }
 }

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/model/InstallChartOptionsBuilderTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/model/InstallChartOptionsBuilderTest.java
@@ -81,6 +81,6 @@ class InstallChartOptionsBuilderTest {
 
         options.apply(builderMock);
 
-        verify(builderMock, times(2)).keyListOfValuesPair(anyString(), anyList());
+        verify(builderMock, times(2)).optionsWithMultipleValues(anyString(), anyList());
     }
 }

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/proxy/request/chart/ChartInstallRequestTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/proxy/request/chart/ChartInstallRequestTest.java
@@ -44,4 +44,6 @@ class ChartInstallRequestTest {
                 .isEqualTo(opts)
                 .isNotEqualTo(InstallChartOptions.defaults());
     }
+
+    // TODO: test ChartInstallRequest apply method using mock of builder to verify calls
 }

--- a/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/proxy/request/chart/ChartInstallRequestTest.java
+++ b/fullstack-helm-client/src/test/java/com/hedera/fullstack/helm/client/test/proxy/request/chart/ChartInstallRequestTest.java
@@ -17,15 +17,32 @@
 package com.hedera.fullstack.helm.client.test.proxy.request.chart;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.hedera.fullstack.helm.client.execution.HelmExecutionBuilder;
 import com.hedera.fullstack.helm.client.model.Chart;
 import com.hedera.fullstack.helm.client.model.install.InstallChartOptions;
 import com.hedera.fullstack.helm.client.proxy.request.chart.ChartInstallRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class ChartInstallRequestTest {
+    @Mock
+    InstallChartOptions installChartOptionsMock;
+
+    @Mock
+    Chart chartMock;
+
+    @Mock
+    HelmExecutionBuilder helmExecutionBuilderMock;
+
     @Test
     @DisplayName("Test ChartInstallRequest Chart constructor")
     void testChartInstallRequestChartConstructor() {
@@ -45,5 +62,47 @@ class ChartInstallRequestTest {
                 .isNotEqualTo(InstallChartOptions.defaults());
     }
 
-    // TODO: test ChartInstallRequest apply method using mock of builder to verify calls
+    @Test
+    @DisplayName("Test ChartInstallRequest apply with unqualified chart")
+    void testChartInstallRequestApplyUnqualifiedChart() {
+        final ChartInstallRequest chartInstallRequest =
+                new ChartInstallRequest("mocked", chartMock, installChartOptionsMock);
+        assertThat(chartInstallRequest).isNotNull();
+        assertThat(chartInstallRequest.chart()).isNotNull().isEqualTo(chartMock);
+        assertThat(chartInstallRequest.releaseName()).isEqualTo("mocked");
+        assertThat(chartInstallRequest.options()).isNotNull().isEqualTo(installChartOptionsMock);
+
+        when(installChartOptionsMock.repo()).thenReturn("mockedRepo");
+        when(chartMock.unqualified()).thenReturn("mockedUnqualified");
+        when(helmExecutionBuilderMock.positional("mocked")).thenReturn(helmExecutionBuilderMock);
+        when(helmExecutionBuilderMock.positional("mockedUnqualified")).thenReturn(helmExecutionBuilderMock);
+        chartInstallRequest.apply(helmExecutionBuilderMock);
+        verify(helmExecutionBuilderMock, times(1)).subcommands("install");
+        verify(installChartOptionsMock, times(1)).apply(helmExecutionBuilderMock);
+        verify(installChartOptionsMock, times(2)).repo();
+        verify(chartMock, times(1)).unqualified();
+        verify(helmExecutionBuilderMock, times(2)).positional(anyString());
+    }
+
+    @Test
+    @DisplayName("Test ChartInstallRequest apply with qualified chart")
+    void testChartInstallRequestApplyQualifiedChart() {
+        final ChartInstallRequest chartInstallRequest =
+                new ChartInstallRequest("mocked", chartMock, installChartOptionsMock);
+        assertThat(chartInstallRequest).isNotNull();
+        assertThat(chartInstallRequest.chart()).isNotNull().isEqualTo(chartMock);
+        assertThat(chartInstallRequest.releaseName()).isEqualTo("mocked");
+        assertThat(chartInstallRequest.options()).isNotNull().isEqualTo(installChartOptionsMock);
+
+        when(installChartOptionsMock.repo()).thenReturn(null);
+        when(chartMock.qualified()).thenReturn("mockedQualified");
+        when(helmExecutionBuilderMock.positional("mocked")).thenReturn(helmExecutionBuilderMock);
+        when(helmExecutionBuilderMock.positional("mockedQualified")).thenReturn(helmExecutionBuilderMock);
+        chartInstallRequest.apply(helmExecutionBuilderMock);
+        verify(helmExecutionBuilderMock, times(1)).subcommands("install");
+        verify(installChartOptionsMock, times(1)).apply(helmExecutionBuilderMock);
+        verify(installChartOptionsMock, times(1)).repo();
+        verify(chartMock, times(1)).qualified();
+        verify(helmExecutionBuilderMock, times(2)).positional(anyString());
+    }
 }

--- a/fullstack-service-locator/src/main/java/com/hedera/fullstack/service/locator/api/ArtifactLoader.java
+++ b/fullstack-service-locator/src/main/java/com/hedera/fullstack/service/locator/api/ArtifactLoader.java
@@ -240,13 +240,14 @@ public final class ArtifactLoader {
                             .map(Path::toAbsolutePath)
                             .forEach(this::addArtifact);
                 } catch (final IOException e) {
-                    LOGGER.atWarn()
-                            .setCause(e)
-                            .log("Failed to walk directory, skipping artifact identification [ path = '{}' ]", current);
+                    LOGGER.warn(
+                            String.format(
+                                    "Failed to walk directory, skipping artifact identification [ path = '%s' ]",
+                                    current),
+                            e);
                 }
             } else {
-                LOGGER.atWarn()
-                        .log("Skipping artifact identification, file is not a JAR archive [ path = '{}' ]", current);
+                LOGGER.warn("Skipping artifact identification, file is not a JAR archive [ path = '{}' ]", current);
             }
         }
     }
@@ -266,12 +267,11 @@ public final class ArtifactLoader {
                 classPath.add(artifact);
             }
         } catch (final IOException e) {
-            LOGGER.atWarn()
-                    .setCause(e)
-                    .log(
-                            "Failed to identify artifact, an I/O error occurred [ fileName = '{}', path = '{}' ]",
-                            artifact.getFileName(),
-                            artifact);
+            LOGGER.warn(
+                    String.format(
+                            "Failed to identify artifact, an I/O error occurred [ fileName = '%s', path = '%s' ]",
+                            artifact.getFileName(), artifact),
+                    e);
         }
     }
 
@@ -308,11 +308,11 @@ public final class ArtifactLoader {
                     try {
                         return uri.toURL();
                     } catch (final MalformedURLException e) {
-                        LOGGER.atWarn()
-                                .setCause(e)
-                                .log(
-                                        "Failed to convert path to URL, unable to load class path entry [ path = '{}' ]",
-                                        uri.getPath());
+                        LOGGER.warn(
+                                String.format(
+                                        "Failed to convert path to URL, unable to load class path entry [ path = '%s' ]",
+                                        uri.getPath()),
+                                e);
                         return null;
                     }
                 })
@@ -331,7 +331,7 @@ public final class ArtifactLoader {
         Objects.requireNonNull(parentLayer, "parentLayer must not be null");
 
         if (modulePath.isEmpty()) {
-            LOGGER.atDebug().log("No module path entries found, skipping module layer creation");
+            LOGGER.debug("No module path entries found, skipping module layer creation");
             return;
         }
 
@@ -341,10 +341,10 @@ public final class ArtifactLoader {
                     parentLayer.configuration().resolveAndBind(finder, ModuleFinder.of(), Collections.emptySet());
             moduleLayer = parentLayer.defineModulesWithOneLoader(cfg, classLoader);
         } catch (LayerInstantiationException | SecurityException e) {
-            LOGGER.atError().setCause(e).log("Failed to instantiate module layer, unable to load module path entries");
+            LOGGER.error("Failed to instantiate module layer, unable to load module path entries", e);
             throw new ArtifactLoadingException(e);
         } catch (FindException | ResolutionException e) {
-            LOGGER.atError().setCause(e).log("Failed to resolve modules, unable to load module path entries");
+            LOGGER.error("Failed to resolve modules, unable to load module path entries", e);
             throw new ArtifactLoadingException(e);
         }
     }


### PR DESCRIPTION
## Description

This pull request changes the following:

- enhance Helm Install to support multiple set parameters
- enhance Helm Install to support multiple values parameters
- downgrade to traditional SLF4J methods to support Gradle's SLF4J 1.7 runtime
- improve HelmExecution.responseAs() HelmExecutionException
- improved HelmClientTest to reduce helm client commands and remove inconsistent test case failures
- improve test coverage for ChartInstallRequest.apply()

PR Walkthrough (13 minutes): https://www.loom.com/share/bff374ec190a44c3aadac2f787bf13f7?sid=7e32aad3-abde-4f7b-90d6-4ba22485edd7

### Related Issues

- Closes #366
- relates to #304
