### PR TITLE
feat: apply nodeSelector and tolerations to all pods including proxies

### DIFF
--- a/charts/hedera-network/templates/network-node-statefulset.yaml
+++ b/charts/hedera-network/templates/network-node-statefulset.yaml
@@ -37,9 +37,9 @@ spec:
         fullstack.hedera.com/type: network-node
         fullstack.hedera.com/node-name: {{ $node.name }}
     spec:
-      {{- if $.Values.deployment.nodeSelectors }}
+      {{- if $.Values.deployment.nodeSelector }}
       nodeSelector:
-      {{- $.Values.deployment.nodeSelectors | toYaml | nindent 8 }}
+      {{- $.Values.deployment.nodeSelector | toYaml | nindent 8 }}
       {{- end }}
       {{- if $.Values.deployment.tolerations }}
       tolerations:

--- a/charts/hedera-network/templates/proxy/envoy-deployment.yaml
+++ b/charts/hedera-network/templates/proxy/envoy-deployment.yaml
@@ -19,6 +19,22 @@ spec:
         app: envoy-proxy-{{ $node.name }}
         fullstack.hedera.com/type: envoy-proxy
     spec:
+        {{- if $.Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- $.Values.deployment.nodeSelector | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.deployment.tolerations }}
+      tolerations:
+        {{- $.Values.deployment.tolerations | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.deployment.affinity }}
+      affinity:
+        {{- $.Values.deployment.affinity | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.deployment.priorityClassName }}
+      priorityClassName: {{ $.Values.deployment.priorityClassName }}
+        {{- end }}
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
       volumes:
         - name: config-volume
           configMap:

--- a/charts/hedera-network/templates/proxy/haproxy-deployment.yaml
+++ b/charts/hedera-network/templates/proxy/haproxy-deployment.yaml
@@ -19,6 +19,22 @@ spec:
         app: haproxy-{{ $node.name }}
         fullstack.hedera.com/type: haproxy
     spec:
+        {{- if $.Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- $.Values.deployment.nodeSelector | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.deployment.tolerations }}
+      tolerations:
+        {{- $.Values.deployment.tolerations | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.deployment.affinity }}
+      affinity:
+        {{- $.Values.deployment.affinity | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if $.Values.deployment.priorityClassName }}
+      priorityClassName: {{ $.Values.deployment.priorityClassName }}
+        {{- end }}
+      terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
       volumes:
         - name: haproxy-config-volume
           configMap:

--- a/charts/hedera-network/templates/tests/test-deployment.yaml
+++ b/charts/hedera-network/templates/tests/test-deployment.yaml
@@ -8,6 +8,22 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   serviceAccountName: pod-monitor
+    {{- if $.Values.deployment.nodeSelector }}
+  nodeSelector:
+    {{- $.Values.deployment.nodeSelector | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $.Values.deployment.tolerations }}
+  tolerations:
+    {{- $.Values.deployment.tolerations | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $.Values.deployment.affinity }}
+  affinity:
+    {{- $.Values.deployment.affinity | toYaml | nindent 8 }}
+    {{- end }}
+    {{- if $.Values.deployment.priorityClassName }}
+  priorityClassName: {{ $.Values.deployment.priorityClassName }}
+    {{- end }}
+  terminationGracePeriodSeconds: {{ $.Values.terminationGracePeriodSeconds }}
   volumes:
     - name: test-volume
       configMap:

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -217,6 +217,18 @@ minio-server:
         name: pool-1
         volumesPerServer: 1
         size: 10Gi
+        nodeSelector:
+          fullstack-scheduling.io/os: linux
+          fullstack-scheduling.io/role: network
+        tolerations:
+          - key: "fullstack-scheduling.io/os"
+            operator: "Equal"
+            value: "linux"
+            effect: "NoSchedule"
+          - key: "fullstack-scheduling.io/role"
+            operator: "Equal"
+            value: "network"
+            effect: "NoSchedule"
     configuration:
       name: minio-secrets
     certificate:
@@ -230,6 +242,18 @@ hedera-mirror-node:
   # importer is a component of the hedera mirror node
   # config for subchart hedera-mirror/importer
   importer:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
     envFrom:
       - secretRef:
           name: mirror-passwords
@@ -251,10 +275,180 @@ hedera-mirror-node:
               allowAnonymousAccess: false
               bucketName: "fst-streams"
               # for s3 configuration of mirror node look at uploader-mirror-secrets.yaml
+  graphql:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
+  grpc:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
+  monitor:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
+  postgresql:
+    postgresql:
+      nodeSelector:
+        fullstack-scheduling.io/os: linux
+        fullstack-scheduling.io/role: network
+      tolerations:
+        - key: "fullstack-scheduling.io/os"
+          operator: "Equal"
+          value: "linux"
+          effect: "NoSchedule"
+        - key: "fullstack-scheduling.io/role"
+          operator: "Equal"
+          value: "network"
+          effect: "NoSchedule"
+    pgpool:
+      nodeSelector:
+        fullstack-scheduling.io/os: linux
+        fullstack-scheduling.io/role: network
+      tolerations:
+        - key: "fullstack-scheduling.io/os"
+          operator: "Equal"
+          value: "linux"
+          effect: "NoSchedule"
+        - key: "fullstack-scheduling.io/role"
+          operator: "Equal"
+          value: "network"
+          effect: "NoSchedule"
+    witness:
+      nodeSelector:
+        fullstack-scheduling.io/os: linux
+        fullstack-scheduling.io/role: network
+      tolerations:
+        - key: "fullstack-scheduling.io/os"
+          operator: "Equal"
+          value: "linux"
+          effect: "NoSchedule"
+        - key: "fullstack-scheduling.io/role"
+          operator: "Equal"
+          value: "network"
+          effect: "NoSchedule"
+  redis:
+    master:
+      nodeSelector:
+        fullstack-scheduling.io/os: linux
+        fullstack-scheduling.io/role: network
+      tolerations:
+        - key: "fullstack-scheduling.io/os"
+          operator: "Equal"
+          value: "linux"
+          effect: "NoSchedule"
+        - key: "fullstack-scheduling.io/role"
+          operator: "Equal"
+          value: "network"
+          effect: "NoSchedule"
+    replica:
+      nodeSelector:
+        fullstack-scheduling.io/os: linux
+        fullstack-scheduling.io/role: network
+      tolerations:
+        - key: "fullstack-scheduling.io/os"
+          operator: "Equal"
+          value: "linux"
+          effect: "NoSchedule"
+        - key: "fullstack-scheduling.io/role"
+          operator: "Equal"
+          value: "network"
+          effect: "NoSchedule"
+  rest:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
+    monitor:
+      nodeSelector:
+        fullstack-scheduling.io/os: linux
+        fullstack-scheduling.io/role: network
+      tolerations:
+        - key: "fullstack-scheduling.io/os"
+          operator: "Equal"
+          value: "linux"
+          effect: "NoSchedule"
+        - key: "fullstack-scheduling.io/role"
+          operator: "Equal"
+          value: "network"
+          effect: "NoSchedule"
+  rosetta:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
+  web3:
+    nodeSelector:
+      fullstack-scheduling.io/os: linux
+      fullstack-scheduling.io/role: network
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
 
 # hedera explorer configuration
 hedera-explorer:
   enable: true
+  nodeSelector:
+    fullstack-scheduling.io/os: linux
+    fullstack-scheduling.io/role: network
+  tolerations:
+    - key: "fullstack-scheduling.io/os"
+      operator: "Equal"
+      value: "linux"
+      effect: "NoSchedule"
+    - key: "fullstack-scheduling.io/role"
+      operator: "Equal"
+      value: "network"
+      effect: "NoSchedule"
   global:
     namespaceOverride: "{{ tpl (.Values.global.namespaceOverride | toString) }}"
   # The hedera explorer UI /api url will proxy  all request to mirror node
@@ -280,7 +474,7 @@ hedera-explorer:
 deployment:
   podAnnotations: {}
   podLabels: {}
-  nodeSelectors:
+  nodeSelector:
     fullstack-scheduling.io/os: linux
     fullstack-scheduling.io/role: network
   tolerations:

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -218,7 +218,6 @@ minio-server:
         volumesPerServer: 1
         size: 10Gi
         nodeSelector:
-          fullstack-scheduling.io/os: linux
           fullstack-scheduling.io/role: network
         tolerations:
           - key: "fullstack-scheduling.io/os"
@@ -251,7 +250,6 @@ hedera-mirror-node:
   # config for subchart hedera-mirror/importer
   importer:
     nodeSelector:
-      fullstack-scheduling.io/os: linux
       fullstack-scheduling.io/role: network
     tolerations:
       - key: "fullstack-scheduling.io/os"
@@ -298,7 +296,6 @@ hedera-mirror-node:
                 exclude: redis
   grpc:
     nodeSelector:
-      fullstack-scheduling.io/os: linux
       fullstack-scheduling.io/role: network
     tolerations:
       - key: "fullstack-scheduling.io/os"
@@ -324,7 +321,6 @@ hedera-mirror-node:
   postgresql:
     postgresql:
       nodeSelector:
-        fullstack-scheduling.io/os: linux
         fullstack-scheduling.io/role: network
       tolerations:
         - key: "fullstack-scheduling.io/os"
@@ -339,7 +335,6 @@ hedera-mirror-node:
       replicaCount: 0
   rest:
     nodeSelector:
-      fullstack-scheduling.io/os: linux
       fullstack-scheduling.io/role: network
     tolerations:
       - key: "fullstack-scheduling.io/os"
@@ -354,7 +349,6 @@ hedera-mirror-node:
       enabled: false
   web3:
     nodeSelector:
-      fullstack-scheduling.io/os: linux
       fullstack-scheduling.io/role: network
     tolerations:
       - key: "fullstack-scheduling.io/os"
@@ -370,7 +364,6 @@ hedera-mirror-node:
 hedera-explorer:
   enable: true
   nodeSelector:
-    fullstack-scheduling.io/os: linux
     fullstack-scheduling.io/role: network
   tolerations:
     - key: "fullstack-scheduling.io/os"
@@ -407,7 +400,6 @@ deployment:
   podAnnotations: {}
   podLabels: {}
   nodeSelector:
-    fullstack-scheduling.io/os: linux
     fullstack-scheduling.io/role: network
   tolerations:
     - key: "fullstack-scheduling.io/os"

--- a/charts/hedera-network/values.yaml
+++ b/charts/hedera-network/values.yaml
@@ -237,6 +237,14 @@ minio-server:
 # hedera mirror node configuration
 hedera-mirror-node:
   enable: true
+  graphql: # not needed for default FST use case
+    enabled: false
+  rosetta: # not needed for default FST use case
+    enabled: false
+  monitor: # not needed for default FST use case
+    enabled: false
+  redis:
+    enabled: false # not needed for default FST use case
   global:
     namespaceOverride: "{{ tpl (.Values.global.namespaceOverride | toString) }}"
   # importer is a component of the hedera mirror node
@@ -275,19 +283,19 @@ hedera-mirror-node:
               allowAnonymousAccess: false
               bucketName: "fst-streams"
               # for s3 configuration of mirror node look at uploader-mirror-secrets.yaml
-  graphql:
-    nodeSelector:
-      fullstack-scheduling.io/os: linux
-      fullstack-scheduling.io/role: network
-    tolerations:
-      - key: "fullstack-scheduling.io/os"
-        operator: "Equal"
-        value: "linux"
-        effect: "NoSchedule"
-      - key: "fullstack-scheduling.io/role"
-        operator: "Equal"
-        value: "network"
-        effect: "NoSchedule"
+            parser:
+              record:
+                entity:
+                  notify:
+                    enabled: true
+                  redis:
+                    enabled: false
+      management:
+        endpoint:
+          health:
+            group:
+              readiness:
+                exclude: redis
   grpc:
     nodeSelector:
       fullstack-scheduling.io/os: linux
@@ -301,19 +309,18 @@ hedera-mirror-node:
         operator: "Equal"
         value: "network"
         effect: "NoSchedule"
-  monitor:
-    nodeSelector:
-      fullstack-scheduling.io/os: linux
-      fullstack-scheduling.io/role: network
-    tolerations:
-      - key: "fullstack-scheduling.io/os"
-        operator: "Equal"
-        value: "linux"
-        effect: "NoSchedule"
-      - key: "fullstack-scheduling.io/role"
-        operator: "Equal"
-        value: "network"
-        effect: "NoSchedule"
+    config:
+      hedera:
+        mirror:
+          grpc:
+            listener:
+              type: NOTIFY
+      management:
+        endpoint:
+          health:
+            group:
+              readiness:
+                exclude: redis
   postgresql:
     postgresql:
       nodeSelector:
@@ -329,58 +336,7 @@ hedera-mirror-node:
           value: "network"
           effect: "NoSchedule"
     pgpool:
-      nodeSelector:
-        fullstack-scheduling.io/os: linux
-        fullstack-scheduling.io/role: network
-      tolerations:
-        - key: "fullstack-scheduling.io/os"
-          operator: "Equal"
-          value: "linux"
-          effect: "NoSchedule"
-        - key: "fullstack-scheduling.io/role"
-          operator: "Equal"
-          value: "network"
-          effect: "NoSchedule"
-    witness:
-      nodeSelector:
-        fullstack-scheduling.io/os: linux
-        fullstack-scheduling.io/role: network
-      tolerations:
-        - key: "fullstack-scheduling.io/os"
-          operator: "Equal"
-          value: "linux"
-          effect: "NoSchedule"
-        - key: "fullstack-scheduling.io/role"
-          operator: "Equal"
-          value: "network"
-          effect: "NoSchedule"
-  redis:
-    master:
-      nodeSelector:
-        fullstack-scheduling.io/os: linux
-        fullstack-scheduling.io/role: network
-      tolerations:
-        - key: "fullstack-scheduling.io/os"
-          operator: "Equal"
-          value: "linux"
-          effect: "NoSchedule"
-        - key: "fullstack-scheduling.io/role"
-          operator: "Equal"
-          value: "network"
-          effect: "NoSchedule"
-    replica:
-      nodeSelector:
-        fullstack-scheduling.io/os: linux
-        fullstack-scheduling.io/role: network
-      tolerations:
-        - key: "fullstack-scheduling.io/os"
-          operator: "Equal"
-          value: "linux"
-          effect: "NoSchedule"
-        - key: "fullstack-scheduling.io/role"
-          operator: "Equal"
-          value: "network"
-          effect: "NoSchedule"
+      replicaCount: 0
   rest:
     nodeSelector:
       fullstack-scheduling.io/os: linux
@@ -395,31 +351,7 @@ hedera-mirror-node:
         value: "network"
         effect: "NoSchedule"
     monitor:
-      nodeSelector:
-        fullstack-scheduling.io/os: linux
-        fullstack-scheduling.io/role: network
-      tolerations:
-        - key: "fullstack-scheduling.io/os"
-          operator: "Equal"
-          value: "linux"
-          effect: "NoSchedule"
-        - key: "fullstack-scheduling.io/role"
-          operator: "Equal"
-          value: "network"
-          effect: "NoSchedule"
-  rosetta:
-    nodeSelector:
-      fullstack-scheduling.io/os: linux
-      fullstack-scheduling.io/role: network
-    tolerations:
-      - key: "fullstack-scheduling.io/os"
-        operator: "Equal"
-        value: "linux"
-        effect: "NoSchedule"
-      - key: "fullstack-scheduling.io/role"
-        operator: "Equal"
-        value: "network"
-        effect: "NoSchedule"
+      enabled: false
   web3:
     nodeSelector:
       fullstack-scheduling.io/os: linux

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -77,7 +77,6 @@ deploy-chart:
 .PHONY: destroy-chart
 destroy-chart:
 	-$(MAKE) uninstall-chart
-	-$(MAKE) destroy-shared
 
 .PHONY: deploy-network
 deploy-network: deploy-chart

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -68,7 +68,6 @@ destroy-shared:
 	-$(MAKE) source "${SCRIPTS_DIR}/main.sh" && destroy_shared
 	-$(MAKE) undeploy-minio-operator
 	-$(MAKE) destroy-prometheus-operator
-	-$(MAKE) destroy-gateway-api # should be destroyed at the end when no more gateway-api CRDs are required
 
 .PHONY: deploy-chart
 deploy-chart:

--- a/dev/dev-cluster.yaml
+++ b/dev/dev-cluster.yaml
@@ -4,5 +4,4 @@ name: fst # this is overridden if CLUSTER_NAME env var is set. Check .env file
 nodes:
   - role: control-plane
     labels:
-      fullstack-scheduling.io/os: linux
       fullstack-scheduling.io/role: network

--- a/dev/scripts/main.sh
+++ b/dev/scripts/main.sh
@@ -121,7 +121,8 @@ function uninstall_chart() {
     echo "Helm chart '${HELM_RELEASE_NAME}' not found in namespace ${NAMESPACE}. Nothing to uninstall. "
  	fi
 
-  kubectl delete ns "${NAMESPACE}" || true
+  # it is needed for GKE deployment
+  kubectl delete secret "sh.helm.release.v1.${HELM_RELEASE_NAME}.v1" || true
 
   log_time "uninstall_chart"
 }

--- a/dev/scripts/main.sh
+++ b/dev/scripts/main.sh
@@ -122,7 +122,11 @@ function uninstall_chart() {
  	fi
 
   # it is needed for GKE deployment
-  kubectl delete secret "sh.helm.release.v1.${HELM_RELEASE_NAME}.v1" || true
+  local has_secret
+  has_secret=$(kubectl get secret | grep -c "sh.helm.release.v1.${HELM_RELEASE_NAME}.*")
+  if [[ $has_secret ]]; then
+    kubectl delete secret "sh.helm.release.v1.${HELM_RELEASE_NAME}.v1" || true
+  fi
 
   log_time "uninstall_chart"
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- add `nodeSelector` and `tolerations` for all pods in the chart and dependent charts
- disable redundant mirror-node containers

### Related Issues

- Closes #373


### Limitations
Some of the dependent charts do not support passing `nodeSelector` and `tolerations`. For example `rest-monitor` in hedera-mirror-node chart. See comment: https://github.com/hashgraph/full-stack-testing/issues/373#issuecomment-1747935956

I have disabled those redundant containers.

