### PR TITLE
feat: add gradle Helm release exists task

### DIFF
--- a/fullstack-examples/build.gradle.kts
+++ b/fullstack-examples/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 import com.hedera.fullstack.gradle.plugin.HelmInstallChartTask
-import com.hedera.fullstack.gradle.plugin.HelmListReleasesTask
+import com.hedera.fullstack.gradle.plugin.HelmReleaseExistsTask
 import com.hedera.fullstack.gradle.plugin.HelmUninstallChartTask
 
 plugins {
@@ -53,9 +53,14 @@ tasks.register<HelmUninstallChartTask>("helmUninstallNginxChart") {
     release.set("nginx-release")
 }
 
-tasks.register<HelmListReleasesTask>("helmListRelease") { namespace.set("nginx-ns") }
+tasks.register<HelmReleaseExistsTask>("helmNginxExists") {
+    allNamespaces.set(true)
+    namespace.set("nginx-ns")
+    release.set("nginx-release")
+}
 
 tasks.check {
     dependsOn("helmInstallNginxChart")
+    dependsOn("helmNginxExists")
     dependsOn("helmUninstallNginxChart")
 }

--- a/fullstack-examples/build.gradle.kts
+++ b/fullstack-examples/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import com.hedera.fullstack.gradle.plugin.HelmInstallChartTask
+import com.hedera.fullstack.gradle.plugin.HelmListReleasesTask
 import com.hedera.fullstack.gradle.plugin.HelmUninstallChartTask
 
 plugins {
@@ -51,6 +52,8 @@ tasks.register<HelmUninstallChartTask>("helmUninstallNginxChart") {
     namespace.set("nginx-ns")
     release.set("nginx-release")
 }
+
+tasks.register<HelmListReleasesTask>("helmListRelease") { namespace.set("nginx-ns") }
 
 tasks.check {
     dependsOn("helmInstallNginxChart")

--- a/fullstack-gradle-plugin/build.gradle.kts
+++ b/fullstack-gradle-plugin/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 dependencies {
     api(platform(project(":fullstack-bom")))
     implementation(project(":fullstack-helm-client"))
+    testImplementation("org.assertj:assertj-core:3.24.2")
 }
 
 gradlePlugin {

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmListReleasesTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmListReleasesTask.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.fullstack.gradle.plugin;
+
+import com.hedera.fullstack.helm.client.HelmClient;
+import com.hedera.fullstack.helm.client.HelmClientBuilder;
+import com.hedera.fullstack.helm.client.model.release.ReleaseItem;
+import java.util.List;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.options.Option;
+
+public abstract class HelmListReleasesTask extends DefaultTask {
+    @Input
+    @Optional
+    @Option(option = "namespace", description = "The namespace to use when listing the releases")
+    public abstract Property<String> getNamespace();
+
+    @TaskAction
+    List<ReleaseItem> listReleases() {
+        HelmClientBuilder helmClientBuilder = HelmClient.builder();
+        if (getNamespace().isPresent()) {
+            helmClientBuilder.defaultNamespace(getNamespace().get());
+        }
+        HelmClient helmClient = helmClientBuilder.build();
+        try {
+            return helmClient.listReleases();
+        } catch (Exception e) {
+            this.getProject()
+                    .getLogger()
+                    .error("HelmListReleasesTask.listReleases() An ERROR occurred while listing the releases: ", e);
+            throw e;
+        }
+    }
+}

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmListReleasesTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmListReleasesTask.java
@@ -27,21 +27,30 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
-public abstract class HelmListReleasesTask extends DefaultTask {
+public abstract class HelmReleaseExistsTask extends DefaultTask {
+    @Input
+    @Option(option = "release", description = "The release to verify exists")
+    public abstract Property<String> getRelease();
+
     @Input
     @Optional
     @Option(option = "namespace", description = "The namespace to use when listing the releases")
     public abstract Property<String> getNamespace();
 
+    @Input
+    @Optional
+    @Option(option = "allNamespaces", description = "True if we should list releases in all namespaces")
+    public abstract Property<Boolean> getAllNamespaces();
+
     @TaskAction
-    List<ReleaseItem> listReleases() {
+    void releaseExists() {
         HelmClientBuilder helmClientBuilder = HelmClient.builder();
         if (getNamespace().isPresent()) {
             helmClientBuilder.defaultNamespace(getNamespace().get());
         }
         HelmClient helmClient = helmClientBuilder.build();
         try {
-            return helmClient.listReleases();
+            List<ReleaseItem> releaseItems = helmClient.listReleases(getAllNamespaces().getOrElse(false));
         } catch (Exception e) {
             this.getProject()
                     .getLogger()

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmReleaseExistsTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmReleaseExistsTask.java
@@ -73,8 +73,10 @@ public abstract class HelmReleaseExistsTask extends DefaultTask {
         }
 
         if (releaseItem == null) {
-            throw new RuntimeException("HelmReleaseExistsTask.releaseExists(): Release "
-                    + getRelease().get() + " does not exist");
+            final String errorMessage = "HelmReleaseExistsTask.releaseExists(): Release "
+                    + getRelease().get() + " does not exist";
+            this.getProject().getLogger().error(errorMessage);
+            throw new RuntimeException(errorMessage);
         }
     }
 }

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
@@ -24,7 +24,6 @@ import com.hedera.fullstack.helm.client.HelmClient;
 import com.hedera.fullstack.helm.client.HelmExecutionException;
 import com.hedera.fullstack.helm.client.model.Chart;
 import com.hedera.fullstack.helm.client.model.Repository;
-import com.hedera.fullstack.helm.client.model.release.ReleaseItem;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -100,20 +99,12 @@ class HelmInstallChartTaskTest {
                     });
             assertThat(helmInstallChartTask.getRelease().get()).isEqualTo(RELEASE_NAME);
             helmInstallChartTask.installChart();
-            HelmListReleasesTask helmListReleasesTask = project.getTasks()
-                    .create("helmListReleases", HelmListReleasesTask.class, task -> {
+            HelmReleaseExistsTask helmReleaseExistsTask = project.getTasks()
+                    .create("helmReleaseExists", HelmReleaseExistsTask.class, task -> {
                         task.getNamespace().set(namespace);
+                        task.getRelease().set(RELEASE_NAME);
                     });
-            List<ReleaseItem> releaseItems = helmListReleasesTask.listReleases();
-            assertThat(releaseItems).isNotNull().isNotEmpty();
-            ReleaseItem releaseItem = releaseItems.stream()
-                    .filter(item -> item.name().equals(RELEASE_NAME))
-                    .findFirst()
-                    .orElse(null);
-            assertThat(releaseItem).isNotNull();
-            assertThat(releaseItem.name()).isEqualTo(RELEASE_NAME);
-            assertThat(releaseItem.namespace()).isEqualTo(namespace);
-            assertThat(releaseItem.status()).isEqualTo("deployed");
+            helmReleaseExistsTask.releaseExists();
             HelmUninstallChartTask helmUninstallChartTask = project.getTasks()
                     .create("helmUninstallChart", HelmUninstallChartTask.class, task -> {
                         task.getNamespace().set(namespace);

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmReleaseExistsTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmReleaseExistsTaskTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.fullstack.gradle.plugin;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class HelmReleaseExistsTaskTest {
+    private static Project project;
+
+    @BeforeAll
+    static void beforeAll() {
+        project = ProjectBuilder.builder().build();
+    }
+
+    @Test
+    @DisplayName("test an error is thrown when the release is not found")
+    void testErrorThrownWhenReleaseNotFound() {
+        RuntimeException e = assertThrows(RuntimeException.class, () -> {
+            HelmReleaseExistsTask helmReleaseExistsTask = project.getTasks()
+                    .create("helmReleaseExistsV1", HelmReleaseExistsTask.class, task -> {
+                        task.getAllNamespaces().set(true);
+                        task.getRelease().set("not-a-release");
+                    });
+            helmReleaseExistsTask.releaseExists();
+        });
+        assertThat(e.getMessage())
+                .isEqualTo("HelmReleaseExistsTask.releaseExists(): Release not-a-release does not exist");
+    }
+
+    @Test
+    @DisplayName("test an error is thrown when the release is not set")
+    void testErrorThrownWhenReleaseNotSet() {
+        NullPointerException npe = assertThrows(NullPointerException.class, () -> {
+            HelmReleaseExistsTask helmReleaseExistsTask = project.getTasks()
+                    .create("helmReleaseExistsV2", HelmReleaseExistsTask.class, task -> {
+                        task.getAllNamespaces().set(true);
+                    });
+            helmReleaseExistsTask.releaseExists();
+        });
+        assertThat(npe.getMessage()).isEqualTo("release must not be null");
+    }
+}


### PR DESCRIPTION
## Description

This pull request changes the following:

- adds a gradle task for checking if the Helm release specified is present, if it is not, it will fail.

This will be used to replace the following in the makefile sunset:
```
.PHONY: is-minio-operator-installed
is-minio-operator-installed:
	@echo ">> Checking for minio operator..."; \
	helm list --namespace=minio-operator | grep minio-operator &> /dev/null && { echo "Found minio operator."; exit 0; }; \
	echo "Minio operator not found."; exit 1
```

### Related Issues

- Closes #326 
