### PR TITLE
feat: add ifExists option to Gradle Helm uninstall task

### DIFF
--- a/fullstack-examples/build.gradle.kts
+++ b/fullstack-examples/build.gradle.kts
@@ -59,8 +59,15 @@ tasks.register<HelmReleaseExistsTask>("helmNginxExists") {
     release.set("nginx-release")
 }
 
+// This task will succeed because it only uninstalls if the release exists
+tasks.register<HelmUninstallChartTask>("helmUninstallNotAChart") {
+    release.set("not-a-release")
+    ifExists.set(true)
+}
+
 tasks.check {
     dependsOn("helmInstallNginxChart")
     dependsOn("helmNginxExists")
     dependsOn("helmUninstallNginxChart")
+    dependsOn("helmUninstallNotAChart")
 }

--- a/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmUninstallChartTask.java
+++ b/fullstack-gradle-plugin/src/main/java/com/hedera/fullstack/gradle/plugin/HelmUninstallChartTask.java
@@ -18,6 +18,9 @@ package com.hedera.fullstack.gradle.plugin;
 
 import com.hedera.fullstack.helm.client.HelmClient;
 import com.hedera.fullstack.helm.client.HelmClientBuilder;
+import com.hedera.fullstack.helm.client.model.release.ReleaseItem;
+import java.util.List;
+import java.util.Objects;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -28,11 +31,18 @@ import org.gradle.api.tasks.options.Option;
 public abstract class HelmUninstallChartTask extends DefaultTask {
     @Input
     @Optional
-    @Option(option = "namespace", description = "The namespace to use when installing the chart")
+    @Option(option = "namespace", description = "The namespace to use when uninstalling the chart")
     public abstract Property<String> getNamespace();
 
     @Input
-    @Option(option = "release", description = "The name of the release to install")
+    @Optional
+    @Option(
+            option = "ifExists",
+            description = "True if we should only uninstall the chart if it exists, default is false")
+    public abstract Property<Boolean> getIfExists();
+
+    @Input
+    @Option(option = "release", description = "The name of the release to uninstall")
     public abstract Property<String> getRelease();
 
     @TaskAction
@@ -42,8 +52,27 @@ public abstract class HelmUninstallChartTask extends DefaultTask {
             helmClientBuilder.defaultNamespace(getNamespace().get());
         }
         HelmClient helmClient = helmClientBuilder.build();
+
         try {
-            helmClient.uninstallChart(getRelease().getOrNull());
+            final String release = getRelease().getOrNull();
+            Objects.requireNonNull(release, "release must not be null");
+
+            if (getIfExists().getOrElse(false)) {
+                List<ReleaseItem> releaseItems = helmClient.listReleases(false);
+                ReleaseItem releaseItem = releaseItems.stream()
+                        .filter(item -> item.name().equals(release))
+                        .findFirst()
+                        .orElse(null);
+                if (releaseItem == null) {
+                    this.getProject()
+                            .getLogger()
+                            .warn(
+                                    "HelmUninstallChartTask.uninstallChart() The release {} does not exist, skipping uninstall",
+                                    release);
+                    return;
+                }
+            }
+            helmClient.uninstallChart(release);
         } catch (Exception e) {
             this.getProject()
                     .getLogger()

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmInstallChartTaskTest.java
@@ -109,6 +109,7 @@ class HelmInstallChartTaskTest {
                     .create("helmUninstallChart", HelmUninstallChartTask.class, task -> {
                         task.getNamespace().set(namespace);
                         task.getRelease().set(RELEASE_NAME);
+                        task.getIfExists().set(true);
                     });
             helmUninstallChartTask.uninstallChart();
         } finally {

--- a/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmUninstallChartTaskTest.java
+++ b/fullstack-gradle-plugin/src/test/java/com/hedera/fullstack/gradle/plugin/HelmUninstallChartTaskTest.java
@@ -38,11 +38,23 @@ class HelmUninstallChartTaskTest {
     void testErrorThrownWhenChartNotFound() {
         assertThrows(HelmExecutionException.class, () -> {
             HelmUninstallChartTask helmUninstallChartTask = project.getTasks()
-                    .create("helmUninstallNonExistingChartChart", HelmUninstallChartTask.class, task -> {
+                    .create("helmUninstallNonExistingChart", HelmUninstallChartTask.class, task -> {
                         task.getNamespace().set("test-failure");
                         task.getRelease().set("not-a-release");
                     });
             helmUninstallChartTask.uninstallChart();
         });
+    }
+
+    @Test
+    @DisplayName("test that an uninstall will pass without error if the ifExists flag is set")
+    void testUninstallIfExists() {
+        HelmUninstallChartTask helmUninstallChartTask = project.getTasks()
+                .create("helmUninstallIfExists", HelmUninstallChartTask.class, task -> {
+                    task.getNamespace().set("test-failure");
+                    task.getRelease().set("not-a-release");
+                    task.getIfExists().set(true);
+                });
+        helmUninstallChartTask.uninstallChart();
     }
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- add ifExists option to Gradle Helm uninstall task

Note: this will help replace the existing makefile code such as:
```
  local count=$(helm list -q -n "${NAMESPACE}" | grep -c "${HELM_RELEASE_NAME}")
  if [[ $count -ne 0 ]]; then
    echo "Uninstalling helm chart ${HELM_RELEASE_NAME} in namespace ${NAMESPACE}... "
    echo "-----------------------------------------------------------------------------------------------------"
 	  helm uninstall -n "${NAMESPACE}" "${HELM_RELEASE_NAME}"
 	  sleep 10
    echo "Uninstalled helm chart ${HELM_RELEASE_NAME} in namespace ${NAMESPACE}"
  else
    echo "Helm chart '${HELM_RELEASE_NAME}' not found in namespace ${NAMESPACE}. Nothing to uninstall. "
 	fi
```

### Related Issues

- Closes #391 
