### PR TITLE
fix: store hedera-explorer chart as dependency until next official version is released

### DIFF
--- a/charts/hedera-network/charts/hedera-explorer/.helmignore
+++ b/charts/hedera-network/charts/hedera-explorer/.helmignore
@@ -1,0 +1,23 @@
+# OS
+.DS_Store
+
+# VCS
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Backup
+*.swp
+*.bak
+*.tmp
+*~
+
+# IDE
+.project
+.idea/
+.vscode/
+*.tmproj

--- a/charts/hedera-network/charts/hedera-explorer/templates/configmap.yaml
+++ b/charts/hedera-network/charts/hedera-explorer/templates/configmap.yaml
@@ -46,7 +46,7 @@ data:
           
           {{- range $path, $backend := .Values.proxyPass }}
           location {{ $path }} {
-            proxy_pass {{ $backend }};
+            proxy_pass {{ tpl $backend $ }};
           }
           {{- end }}
 

--- a/charts/hedera-network/charts/hedera-explorer/values.yaml
+++ b/charts/hedera-network/charts/hedera-explorer/values.yaml
@@ -158,10 +158,13 @@ volumes:
     configMap:
       name: '{{ include "hedera-explorer.fullname" . }}-config'
 
-# Add custom reverse proxy configuration
+# Add custom reverse proxy configuration.
+# It is a key-value map where key is the path and value being a URL.
 # Primary use case is to allow access to mirror node api via hedera explorer url
+# Note that templating is allowed in the values
+# Example:
+#   /api: "http://{{ .Release.Name }}-rest"
 proxyPass: {}
-  # /api: http://fst-rest
 
 config: |
   [


### PR DESCRIPTION

## Description

This pull request changes the following:

- fix: store hedera-explorer chart as dependency until next official version is released

This is to store [this](https://github.com/hashgraph/hedera-mirror-node-explorer/commit/7ba2721c3796403bb7d142df697ba3f2a7d68bff) change in our repo.

### Related Issues

- Closes #434 
