### PR TITLE
chore(ci): publish CLI to Github NPM package registry

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -169,7 +169,14 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
+        with:
+          node-version: 18
+
       - name: Publish NPM Package
+        working-directory: fullstack-network-manager
         run:
           npm publish
 

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -162,23 +162,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
-
-      - name: Login to GitHub NPM Package Registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Setup Node
+      - name: Install Node
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
         with:
           node-version: 18
-
       - name: Publish NPM Package
-        working-directory: fullstack-network-manager
-        run:
-          npm publish
+        working-directory: "fullstack-network-manager"
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm ci && npm publish
 
   create-github-release:
     name: Github / Release

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Extract Version
         id: tag
         run: |
+          cat VERSION
           [[ ! -f "${VERSION}" ]] && exit 1  # error on missing VERSION file
           echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
 

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -170,7 +170,7 @@ jobs:
         working-directory: "fullstack-network-manager"
         env:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci && npm publish
+        run: npm ci && npm publish ${{ github.event.inputs.dry-run-enabled && '--dry-run' || '' }}
 
   create-github-release:
     name: Github / Release

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -80,7 +80,9 @@ jobs:
 
       - name: Extract Version
         id: tag
-        run: echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
+        run: |
+          if [[ ! -f "${VERSION}" ]]; exit 1  # error on missing VERSION file
+          echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
 
   publish-maven-central:
     name: Publish

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -172,7 +172,7 @@ jobs:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm ci 
-          npm i replace-json-property && ./node_modules/replace-json-property/bin/replace-json-property.bin.js package.json ${{ needs.prepare-release.outputs.version }} && cat package.json | grep 'version'
+          npm i replace-json-property && ./node_modules/replace-json-property/bin/replace-json-property.bin.js package.json version ${{ needs.prepare-release.outputs.version }} && cat package.json | grep 'version'
           npm publish ${{ github.event.inputs.dry-run-enabled && '--dry-run' || '' }}
 
   create-github-release:

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -170,7 +170,10 @@ jobs:
         working-directory: "fullstack-network-manager"
         env:
           NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm ci && npm publish ${{ github.event.inputs.dry-run-enabled && '--dry-run' || '' }}
+        run: |
+          npm ci 
+          npm i replace-json-property && ./node_modules/replace-json-property/bin/replace-json-property.bin.js package.json ${{ needs.prepare-release.outputs.version }} && cat package.json | grep 'version'
+          npm publish ${{ github.event.inputs.dry-run-enabled && '--dry-run' || '' }}
 
   create-github-release:
     name: Github / Release

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -155,7 +155,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}/kubectl-bats:${{ needs.prepare-release.outputs.version }}
 
   publish-npm-packages:
-    name: Publish NPM Packages
+    name: Publish / NPM Packages
     runs-on: [self-hosted, Linux, medium, ephemeral]
     needs:
       - prepare-release

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Extract Version
         id: tag
         run: |
-          if [[ ! -f "${VERSION}" ]]; exit 1  # error on missing VERSION file
+          [[ ! -f "${VERSION}" ]] && exit 1  # error on missing VERSION file
           echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
 
   publish-maven-central:

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -154,12 +154,32 @@ jobs:
           push: ${{ github.event.inputs.dry-run-enabled != 'true' }}
           tags: ghcr.io/${{ github.repository }}/kubectl-bats:${{ needs.prepare-release.outputs.version }}
 
+  publish-npm-packages:
+    name: Publish NPM Packages
+    runs-on: [self-hosted, Linux, medium, ephemeral]
+    needs:
+      - prepare-release
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
+      - name: Login to GitHub NPM Package Registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish NPM Package
+        run:
+          npm publish
+
   create-github-release:
     name: Github / Release
     runs-on: [self-hosted, Linux, medium, ephemeral]
     needs:
       - publish-maven-central
       - publish-docker-image
+      - publish-npm-packages
     if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
     steps:
       - name: Checkout Code

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -82,7 +82,7 @@ jobs:
         id: tag
         run: |
           cat VERSION
-          [[ ! -f "${VERSION}" ]] && exit 1  # error on missing VERSION file
+          [[ ! -f VERSION ]] && echo "VERSION file is not found" && exit 1  # error on missing VERSION file
           echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
 
   publish-maven-central:

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -57,6 +57,7 @@ jobs:
       custom-job-label: Standard
       enable-unit-tests: false
       enable-nodejs-tests: true
+      node-version: 18
 
   codecov:
     name: CodeCov

--- a/.releaserc
+++ b/.releaserc
@@ -48,7 +48,7 @@
       "channel": "alpha"
     },
     {
-      "name": "444-publish-cli-to-npm-registry",
+      "name": "ci/*",
       "prerelease": "alpha",
       "channel": "alpha"
     },

--- a/.releaserc
+++ b/.releaserc
@@ -48,6 +48,11 @@
       "channel": "alpha"
     },
     {
+      "name": "444-publish-cli-to-npm-registry",
+      "prerelease": "alpha",
+      "channel": "alpha"
+    },
+    {
       "name": "beta/*",
       "prerelease": "beta",
       "channel": "beta"

--- a/.releaserc
+++ b/.releaserc
@@ -26,7 +26,9 @@
       {
         "assets": [
           "gradle.properties",
-          "charts/fullstack-deployment/Chart.yaml"
+          "charts/fullstack-deployment/Chart.yaml",
+          "charts/fullstack-cluster-setup/Chart.yaml",
+          "charts/fullstack-network-manager/package.json"
         ]
       }
     ]

--- a/build-logic/project-plugins/src/main/kotlin/Utils.kt
+++ b/build-logic/project-plugins/src/main/kotlin/Utils.kt
@@ -44,7 +44,13 @@ class Utils {
             updateHelmCharts(project) {chart ->
                 updateHelmChartVersion(project, chart.name, newVersion)
             }
-         }
+        }
+
+        @JvmStatic
+        fun updateFullstackNetworkManagerVersion(project: Project, newVersion: SemVer) {
+            val manifestFile = File(project.rootProject.projectDir, "fullstack-network-manager/package.json")
+            updateStringInFile(manifestFile, "\"version\":", "  \"version\": \"${newVersion}\",")
+        }
 
         @JvmStatic
         fun updateHelmChartAppVersion(project: Project, newVersion: SemVer) {

--- a/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.aggregate-reports.gradle.kts
+++ b/build-logic/project-plugins/src/main/kotlin/com.hedera.fullstack.aggregate-reports.gradle.kts
@@ -59,6 +59,7 @@ tasks.register("versionAsSpecified") {
         val newVer = SemVer.parse(verStr)
         Utils.updateHelmChartVersion(project, newVer)
         Utils.updateHelmChartAppVersion(project, newVer)
+        Utils.updateFullstackNetworkManagerVersion(project, newVer)
         Utils.updateVersion(project, newVer)
     }
 }
@@ -71,6 +72,7 @@ tasks.register("versionAsSnapshot") {
 
         Utils.updateHelmChartVersion(project, newVer)
         Utils.updateHelmChartAppVersion(project, newVer)
+        Utils.updateFullstackNetworkManagerVersion(project, newVer)
         Utils.updateVersion(project, newVer)
     }
 }

--- a/fullstack-network-manager/.npmrc
+++ b/fullstack-network-manager/.npmrc
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}
+@hashgraph:registry=https://npm.pkg.github.com

--- a/fullstack-network-manager/README.md
+++ b/fullstack-network-manager/README.md
@@ -2,21 +2,15 @@
 
 fullstack-network-manager is a CLI tool to manage and deploy a Hedera Network using Helm chart for local testing.
 
-## Develop
-- In order to support ES6 modules with `jest`, set an env variable `export NODE_OPTIONS=--experimental-vm-modules >> ~/.zshrc`
-  - If you are using Intellij and would like to use debugger tools, you will need to enable `--experimental-vm-modules` for `Jest`. 
-    - `Run->Edit Configurations->Edit Configuration Templates->Jest` and then set `--experimental-vm-modules` in `Node Options`. 
-- Run `npx jest` or `npm test` to run the tests
-- Run `npm link` so that the CLI can be run using `fsnetman` in the terminal
-
 ## Install
-- Run `nmp -i @hedera/fullstack-network-manager`
-  - In order to install directly from this repository, run `npm link` from this directory.
-- Once installed, the CLI will available as the following aliases:
-    - `fsnetman`
+- Create or update `~/.npmrc` file and specify the Github package registry: `@hashgraph:registry=https://npm.pkg.github.com`
+```
+❯ cat ~/.npmrc
+@hashgraph:registry=https://npm.pkg.github.com
+```
+- Run `nmp install -g @hedera/fullstack-network-manager`
 
-## Command Examples
-
+- Run `fsnetman` from a terminal as shown below
 ``` 
 ❯ fsnetman
 Usage: fsnetman <command> [options]
@@ -31,3 +25,29 @@ Options:
 
 Select a command
 ```
+## Develop
+- In order to support ES6 modules with `jest`, set an env variable `export NODE_OPTIONS=--experimental-vm-modules >> ~/.zshrc`
+  - If you are using Intellij and would like to use debugger tools, you will need to enable `--experimental-vm-modules` for `Jest`.
+    - `Run->Edit Configurations->Edit Configuration Templates->Jest` and then set `--experimental-vm-modules` in `Node Options`.
+- Run `npm test` to run the tests
+- Run `npm run fsnetman` to access the CLI as shown below:
+```
+❯ npm run fsnetman
+
+> @hashgraph/fullstack-network-manager@0.1.0 fsnetman
+> NODE_OPTIONS=--experimental-vm-modules node fsnetman.mjs
+
+Usage: fsnetman.mjs <command> [options]
+
+Commands:
+  fsnetman.mjs init     Perform dependency checks and initialize local environme
+                        nt
+  fsnetman.mjs cluster  Manager FST cluster
+
+Options:
+  -h, --help     Show help                                             [boolean]
+  -v, --version  Show version number                                   [boolean]
+
+Select a command
+```
+

--- a/fullstack-network-manager/package.json
+++ b/fullstack-network-manager/package.json
@@ -1,17 +1,18 @@
 {
-  "name": "@hedera/fullstack-network-manager",
-  "version": "1.0.0",
+  "name": "@hashgraph/fullstack-network-manager",
+  "version": "0.1.0",
   "description": "Fullstack-Network-Manager is a CLI tool to manage and deploy a Hedera Network using Helm chart for local testing.",
   "main": "src/index.mjs",
   "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "bin": {
     "fsnetman": "fsnetman.mjs"
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "fsnetman": "NODE_OPTIONS=--experimental-vm-modules node fsnetman.mjs"
   },
   "keywords": [
     "fullstack-network-manager",
@@ -31,5 +32,18 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "jest": "^29.7.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hashgraph/full-stack-testing.git",
+    "directory": "fullstack-network-manager"
+  },
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "engines": {
+    "node": ">=18.18.2",
+    "npm": ">=9.8.1"
   }
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- publish cli to Github NPM package registry
- update semantic-release config to include `package.json` from CLI with updated version
- update semantic-release config to include `Chart.yaml` from `fullstack-cluster-setup` with updated version
- added some debug logic for CI pipeline
- allow `ci/*` branches to be used to dry-run semantic release process for debugging

Attempted to dry-run [here](https://github.com/hashgraph/full-stack-testing/actions/runs/6699421036/job/18203532543)
### Related Issues

- Closes #444
