### PR TITLE
feat(cli): implement cluster create and delete commands

### DIFF
--- a/fullstack-network-manager/resources/dev-cluster.yaml
+++ b/fullstack-network-manager/resources/dev-cluster.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: fst # this is overridden if CLUSTER_NAME env var is set. Check .env file
+nodes:
+  - role: control-plane
+    labels:
+      fullstack-scheduling.io/role: network

--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -11,7 +11,7 @@ export const BaseCommand = class BaseCommand {
     async checkKind() {
         try {
             this.logger.debug("Checking if 'kind' is installed")
-            await this.runExec("kind --version")
+            await this.runExec("kind")
             this.logger.debug("OK: 'kind' is installed")
         } catch (e) {
             this.logger.error("%s", e)
@@ -28,7 +28,7 @@ export const BaseCommand = class BaseCommand {
     async checkHelm() {
         try {
             this.logger.debug("Checking if 'helm' is installed")
-            await this.runExec("helm version")
+            await this.runExec("helm")
             this.logger.debug("OK: 'helm' is installed")
         } catch (e) {
             this.logger.error("%s", e)
@@ -45,7 +45,7 @@ export const BaseCommand = class BaseCommand {
     async checkKubectl() {
         try {
             this.logger.debug("Checking if 'kubectl' is installed")
-            await this.runExec("kubectl version")
+            await this.runExec("kubectl")
             this.logger.debug("OK: 'kubectl' is installed")
         } catch (e) {
             this.logger.error("%s", e)
@@ -61,7 +61,7 @@ export const BaseCommand = class BaseCommand {
      * @returns {Promise<boolean>}
      */
     async checkDependencies(deps = []) {
-        this.logger.info("Checking for required dependencies: %s", deps)
+        this.logger.debug("Checking for required dependencies: %s", deps)
 
         for (let i = 0; i < deps.length; i++) {
             let dep = deps[i]
@@ -69,21 +69,21 @@ export const BaseCommand = class BaseCommand {
 
             let check = this.checks.get(dep)
             if (!check) {
-                this.logger.error("FAIL: Dependency '%s' is unknown", dep)
+                this.logger.error("Dependency '%s' is unknown", dep)
                 return false
             }
 
-
             let status = await check()
             if (!status) {
-                this.logger.error("FAIL: Dependency '%s' is not found", dep)
+                this.logger.error("Dependency '%s' is not found", dep)
                 return false
             }
 
             this.logger.debug("PASS: Dependency '%s' is found", dep)
         }
 
-        this.logger.info("PASS: All required dependencies are found: %s", deps)
+        this.logger.debug("All required dependencies are found: %s", deps)
+
         return true
     }
 

--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -1,6 +1,7 @@
 "use strict"
 import {exec} from "child_process";
 import * as core from "../core/index.mjs"
+import * as util from "util";
 
 export const BaseCommand = class BaseCommand {
     /**
@@ -93,14 +94,22 @@ export const BaseCommand = class BaseCommand {
      */
     runExec(cmd) {
         return new Promise((resolve, reject) => {
-            exec(cmd, (error, stdout, stderr) => {
+            exec(cmd, (error, stderr, stdout) => {
                 if (error) {
                     reject(error)
                 }
 
+                console.log(stderr)
+                console.log(stdout)
+
                 resolve(stdout)
             })
         })
+    }
+
+    showUser(msg, ...args) {
+        console.log(util.format(msg, ...args))
+        this.logger.debug(msg, ...args)
     }
 
     constructor(opts) {

--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -94,13 +94,10 @@ export const BaseCommand = class BaseCommand {
      */
     runExec(cmd) {
         return new Promise((resolve, reject) => {
-            exec(cmd, (error, stderr, stdout) => {
+            exec(cmd, (error, stdout, stderr) => {
                 if (error) {
                     reject(error)
                 }
-
-                console.log(stderr)
-                console.log(stdout)
 
                 resolve(stdout)
             })

--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -105,8 +105,9 @@ export const BaseCommand = class BaseCommand {
     }
 
     showUser(msg, ...args) {
-        console.log(util.format(msg, ...args))
-        this.logger.debug(msg, ...args)
+        let formatted = util.format(msg, ...args)
+        console.log(formatted)
+        this.logger.debug(formatted)
     }
 
     constructor(opts) {

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -95,7 +95,6 @@ export const ClusterCommand = class extends BaseCommand {
             this.logger.debug(`Invoking '${cmd}'...`)
             this.showUser(chalk.cyan('Deleting cluster:'), chalk.yellow(`${argv.name}...`))
             await this.runExec(cmd)
-            this.showUser(chalk.green('Deleted cluster:'), chalk.yellow(argv.name))
             await this.getClusters()
 
             return true

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -54,6 +54,7 @@ export const ClusterCommand = class extends BaseCommand {
         let cmd = `kind create cluster -n ${argv.name} --config ${core.constants.RESOURCES_DIR}/dev-cluster.yaml`
 
         try {
+            this.showUser(`Creating cluster '${argv.name}...'`)
             this.logger.debug(`Invoking '${cmd}'...`)
             let output = await this.runExec(cmd)
             this.logger.debug(output)

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -26,11 +26,11 @@ export const ClusterCommand = class extends BaseCommand {
 
         try {
             let output = await this.runExec(cmd)
-            this.showUser("\nList of available clusters \n--------------------------\n%s", output)
+            this.logger.showUser("\nList of available clusters \n--------------------------\n%s", output)
             return true
         } catch (e) {
             this.logger.error("%s", e)
-            this.showUser(e.message)
+            this.logger.showUser(e.message)
         }
 
         return false
@@ -46,11 +46,11 @@ export const ClusterCommand = class extends BaseCommand {
 
         try {
             let output = await this.runExec(cmd)
-            this.showUser(output)
+            this.logger.showUser(output)
             return true
         } catch (e) {
             this.logger.error("%s", e)
-            this.showUser(e.message)
+            this.logger.showUser(e.message)
         }
 
         return false
@@ -65,11 +65,11 @@ export const ClusterCommand = class extends BaseCommand {
         let cmd = `kind create cluster -n ${argv.name} --config ${core.constants.RESOURCES_DIR}/dev-cluster.yaml`
 
         try {
-            this.showUser(chalk.cyan('Creating cluster:'), chalk.yellow(`${argv.name}...`))
+            this.logger.showUser(chalk.cyan('Creating cluster:'), chalk.yellow(`${argv.name}...`))
             this.logger.debug(`Invoking '${cmd}'...`)
             let output = await this.runExec(cmd)
             this.logger.debug(output)
-            this.showUser(chalk.green('Created cluster:'), chalk.yellow(argv.name))
+            this.logger.showUser(chalk.green('Created cluster:'), chalk.yellow(argv.name))
 
             // show all clusters and cluster-info
             await this.getClusters()
@@ -78,7 +78,7 @@ export const ClusterCommand = class extends BaseCommand {
             return true
         } catch (e) {
             this.logger.error("%s", e)
-            this.showUser(e.message)
+            this.logger.showUser(e.message)
         }
 
         return false
@@ -93,14 +93,14 @@ export const ClusterCommand = class extends BaseCommand {
         let cmd = `kind delete cluster -n ${argv.name}`
         try {
             this.logger.debug(`Invoking '${cmd}'...`)
-            this.showUser(chalk.cyan('Deleting cluster:'), chalk.yellow(`${argv.name}...`))
+            this.logger.showUser(chalk.cyan('Deleting cluster:'), chalk.yellow(`${argv.name}...`))
             await this.runExec(cmd)
             await this.getClusters()
 
             return true
         } catch (e) {
             this.logger.error("%s", e.stack)
-            this.showUser(e.message)
+            this.logger.showUser(e.message)
         }
 
         return false
@@ -123,7 +123,9 @@ export const ClusterCommand = class extends BaseCommand {
                             yargs.option('name', clusterNameFlag)
                         },
                         handler: argv => {
-                            clusterCmd.create(argv).then(r => {})
+                            clusterCmd.create(argv).then(r => {
+                                if (!r) process.exit(1)
+                            })
                         }
                     })
                     .command({
@@ -133,14 +135,18 @@ export const ClusterCommand = class extends BaseCommand {
                             yargs.option('name', clusterNameFlag)
                         },
                         handler: argv => {
-                            clusterCmd.delete(argv).then(r => {})
+                            clusterCmd.delete(argv).then(r => {
+                                if (!r) process.exit(1)
+                            })
                         }
                     })
                     .command({
                         command: 'list',
                         desc: 'List all clusters',
                         handler: argv => {
-                            clusterCmd.getClusters().then(r => {})
+                            clusterCmd.getClusters().then(r => {
+                                if (!r) process.exit(1)
+                            })
                         }
                     })
                     .command({
@@ -150,7 +156,9 @@ export const ClusterCommand = class extends BaseCommand {
                             yargs.option('name', clusterNameFlag)
                         },
                         handler: argv => {
-                            clusterCmd.getClusterInfo(argv).then(r => {})
+                            clusterCmd.getClusterInfo(argv).then(r => {
+                                if (!r) process.exit(1)
+                            })
                         }
                     })
                     .demand(1, 'Select a cluster command')

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -16,7 +16,7 @@ const clusterNameFlag = {
  */
 export const ClusterCommand = class extends BaseCommand {
 
-    async getClusters(argv) {
+    async getClusters() {
         let cmd = `kind get clusters`
 
         try {
@@ -60,7 +60,7 @@ export const ClusterCommand = class extends BaseCommand {
             this.showUser("Created cluster '%s'", argv.name)
 
             // show all clusters and cluster-info
-            await this.getClusters(argv)
+            await this.getClusters()
             await this.getClusterInfo(argv)
 
             return true
@@ -83,7 +83,7 @@ export const ClusterCommand = class extends BaseCommand {
             this.logger.debug(`Invoking '${cmd}'...`)
             this.showUser("Deleting cluster '%s'", argv.name)
             await this.runExec(cmd)
-            await this.getClusters(argv)
+            await this.getClusters()
             this.showUser("Deleted cluster '%s'", argv.name)
 
             return true
@@ -128,11 +128,8 @@ export const ClusterCommand = class extends BaseCommand {
                     .command({
                         command: 'list',
                         desc: 'List all clusters',
-                        builder: yargs => {
-                            yargs.option('name', clusterNameFlag)
-                        },
                         handler: argv => {
-                            clusterCmd.getClusters(argv).then()
+                            clusterCmd.getClusters().then()
                         }
                     })
                     .command({

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -22,7 +22,7 @@ export const ClusterCommand = class extends BaseCommand {
 
         try {
             let output = await this.runExec(cmd)
-            this.showUser("\nList of clusters \n----------------\n%s", output)
+            this.showUser("\nList of available clusters \n--------------------------\n%s", output)
             return true
         } catch (e) {
             this.logger.error("%s", e)

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -17,6 +17,10 @@ const clusterNameFlag = {
  */
 export const ClusterCommand = class extends BaseCommand {
 
+    /**
+     * List available clusters
+     * @returns {Promise<boolean>}
+     */
     async getClusters() {
         let cmd = `kind get clusters`
 
@@ -32,6 +36,11 @@ export const ClusterCommand = class extends BaseCommand {
         return false
     }
 
+    /**
+     * Get cluster-info for the given cluster name
+     * @param argv arguments containing cluster name
+     * @returns {Promise<boolean>}
+     */
     async getClusterInfo(argv) {
         let cmd = `kubectl cluster-info --context kind-${argv.name}`
 
@@ -46,6 +55,7 @@ export const ClusterCommand = class extends BaseCommand {
 
         return false
     }
+
     /**
      * Create a cluster
      * @param argv
@@ -114,7 +124,7 @@ export const ClusterCommand = class extends BaseCommand {
                             yargs.option('name', clusterNameFlag)
                         },
                         handler: argv => {
-                            clusterCmd.create(argv).then()
+                            clusterCmd.create(argv).then(r => {})
                         }
                     })
                     .command({
@@ -124,14 +134,14 @@ export const ClusterCommand = class extends BaseCommand {
                             yargs.option('name', clusterNameFlag)
                         },
                         handler: argv => {
-                            clusterCmd.delete(argv).then()
+                            clusterCmd.delete(argv).then(r => {})
                         }
                     })
                     .command({
                         command: 'list',
                         desc: 'List all clusters',
                         handler: argv => {
-                            clusterCmd.getClusters().then()
+                            clusterCmd.getClusters().then(r => {})
                         }
                     })
                     .command({
@@ -141,7 +151,7 @@ export const ClusterCommand = class extends BaseCommand {
                             yargs.option('name', clusterNameFlag)
                         },
                         handler: argv => {
-                            clusterCmd.getClusterInfo(argv).then()
+                            clusterCmd.getClusterInfo(argv).then(r => {})
                         }
                     })
                     .demand(1, 'Select a cluster command')

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -1,5 +1,6 @@
 import * as core from '../core/index.mjs'
 import {BaseCommand} from "./base.mjs";
+import chalk from "chalk";
 
 /**
  * Flags for 'cluster' command
@@ -54,11 +55,11 @@ export const ClusterCommand = class extends BaseCommand {
         let cmd = `kind create cluster -n ${argv.name} --config ${core.constants.RESOURCES_DIR}/dev-cluster.yaml`
 
         try {
-            this.showUser(`Creating cluster '${argv.name}...'`)
+            this.showUser(chalk.cyan('Creating cluster:'), chalk.yellow(`${argv.name}...`))
             this.logger.debug(`Invoking '${cmd}'...`)
             let output = await this.runExec(cmd)
             this.logger.debug(output)
-            this.showUser("Created cluster '%s'", argv.name)
+            this.showUser(chalk.green('Created cluster:'), chalk.yellow(argv.name))
 
             // show all clusters and cluster-info
             await this.getClusters()
@@ -82,10 +83,10 @@ export const ClusterCommand = class extends BaseCommand {
         let cmd = `kind delete cluster -n ${argv.name}`
         try {
             this.logger.debug(`Invoking '${cmd}'...`)
-            this.showUser("Deleting cluster '%s'", argv.name)
+            this.showUser(chalk.cyan('Deleting cluster:'), chalk.yellow(`${argv.name}...`))
             await this.runExec(cmd)
+            this.showUser(chalk.green('Deleted cluster:'), chalk.yellow(argv.name))
             await this.getClusters()
-            this.showUser("Deleted cluster '%s'", argv.name)
 
             return true
         } catch (e) {

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -18,19 +18,48 @@ export const ClusterCommand = class extends BaseCommand {
     /**
      * Create a cluster
      * @param argv
-     * @returns {Promise<void>}
+     * @returns {Promise<boolean>}
      */
     async create(argv) {
-        this.logger.info("creating cluster '%s'", argv.name)
+        let cmd = `kind create cluster -n ${argv.name} --config ${core.constants.RESOURCES_DIR}/dev-cluster.yaml`
+
+        try {
+            this.showUser(`Invoking '${cmd}'...`)
+            let output = await this.runExec(cmd)
+            this.logger.debug(output)
+
+            this.showUser("Created cluster '%s'\n", argv.name)
+            output = await this.runExec(`kubectl cluster-info --context kind-${argv.name}`)
+            this.showUser(output)
+
+            return true
+        } catch (e) {
+            this.logger.error("%s", e)
+            this.showUser(e.message)
+        }
+
+        return false
     }
 
     /**
      * Delete a cluster
      * @param argv
-     * @returns {Promise<void>}
+     * @returns {Promise<boolean>}
      */
     async delete(argv) {
-        this.logger.info("deleting cluster '%s'", argv.name, {name: argv.name})
+        let cmd = `kind delete cluster -n ${argv.name}`
+        try {
+            this.showUser(`Invoking '${cmd}'...`)
+            let output = await this.runExec(cmd)
+            this.showUser(output)
+            this.showUser("Deleted cluster '%s' (if it existed)", argv.name)
+            return true
+        } catch (e) {
+            this.logger.error("%s", e.stack)
+            this.showUser(e.message)
+        }
+
+        return false
     }
 
     /**

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -113,7 +113,7 @@ export const ClusterCommand = class extends BaseCommand {
     static getCommandDefinition(clusterCmd) {
         return {
             command: 'cluster',
-            desc: 'Manager FST cluster',
+            desc: 'Manage FST cluster',
             builder: yargs => {
                 return yargs
                     .command({

--- a/fullstack-network-manager/src/commands/init.mjs
+++ b/fullstack-network-manager/src/commands/init.mjs
@@ -10,11 +10,17 @@ export const InitCommand = class extends BaseCommand {
      * @returns {Promise<boolean>}
      */
     async init() {
-        return await this.checkDependencies([
+        this.logger.info("-------------- Start running `init` --------------")
+
+        let status = await this.checkDependencies([
             core.constants.HELM,
             core.constants.KIND,
             core.constants.KUBECTL,
         ])
+
+        this.logger.info("-------------- Finished running `init` --------------")
+
+        return status
     }
 
     /**

--- a/fullstack-network-manager/src/commands/init.mjs
+++ b/fullstack-network-manager/src/commands/init.mjs
@@ -10,15 +10,19 @@ export const InitCommand = class extends BaseCommand {
      * @returns {Promise<boolean>}
      */
     async init() {
-        this.logger.info("-------------- Start running `init` --------------")
-
-        let status = await this.checkDependencies([
+        let deps = [
             core.constants.HELM,
             core.constants.KIND,
             core.constants.KUBECTL,
-        ])
+        ]
 
-        this.logger.info("-------------- Finished running `init` --------------")
+        let status = await this.checkDependencies(deps)
+        if (!status) {
+            this.showUser("FAIL: Required dependencies are not found: %s", deps)
+            return false
+        }
+
+        this.showUser("PASS: All required dependencies are found: %s", deps)
 
         return status
     }

--- a/fullstack-network-manager/src/commands/init.mjs
+++ b/fullstack-network-manager/src/commands/init.mjs
@@ -1,5 +1,6 @@
 import {BaseCommand} from "./base.mjs";
 import * as core from "../core/index.mjs"
+import chalk from "chalk";
 
 /**
  * Defines the core functionalities of 'init' command
@@ -22,7 +23,7 @@ export const InitCommand = class extends BaseCommand {
             return false
         }
 
-        this.showUser("PASS: All required dependencies are found: %s", deps)
+        this.showUser(chalk.green("All required dependencies are found: %s"), chalk.yellow(deps))
 
         return status
     }

--- a/fullstack-network-manager/src/commands/init.mjs
+++ b/fullstack-network-manager/src/commands/init.mjs
@@ -19,11 +19,10 @@ export const InitCommand = class extends BaseCommand {
 
         let status = await this.checkDependencies(deps)
         if (!status) {
-            this.showUser("FAIL: Required dependencies are not found: %s", deps)
             return false
         }
 
-        this.showUser(chalk.green("All required dependencies are found: %s"), chalk.yellow(deps))
+        this.logger.showUser(chalk.green("OK: All required dependencies are found: %s"), chalk.yellow(deps))
 
         return status
     }
@@ -38,7 +37,9 @@ export const InitCommand = class extends BaseCommand {
             desc: "Perform dependency checks and initialize local environment",
             builder: {},
             handler: (argv) => {
-                initCmd.init(argv)
+                initCmd.init(argv).then(r => {
+                    if (!r) process.exit(1)
+                })
             }
         }
     }

--- a/fullstack-network-manager/src/core/constants.mjs
+++ b/fullstack-network-manager/src/core/constants.mjs
@@ -11,6 +11,6 @@ export const constants = {
     KIND: 'kind',
     KUBECTL: 'kubectl',
     CWD: process.cwd(),
-    TMP_DIR: ".fsnetman",
+    TMP_DIR: process.env.HOME + "/.fsnetman",
     RESOURCES_DIR: normalize(CUR_FILE_DIR + "/../../resources")
 }

--- a/fullstack-network-manager/src/core/constants.mjs
+++ b/fullstack-network-manager/src/core/constants.mjs
@@ -11,6 +11,6 @@ export const constants = {
     KIND: 'kind',
     KUBECTL: 'kubectl',
     CWD: process.cwd(),
-    TMP_DIR: process.env.HOME + "/.fsnetman",
+    FST_HOME_DIR: process.env.HOME + "/.fsnetman",
     RESOURCES_DIR: normalize(CUR_FILE_DIR + "/../../resources")
 }

--- a/fullstack-network-manager/src/core/constants.mjs
+++ b/fullstack-network-manager/src/core/constants.mjs
@@ -1,3 +1,8 @@
+import {dirname, normalize} from "path"
+import {fileURLToPath} from "url"
+
+// directory of this fle
+const CUR_FILE_DIR = dirname(fileURLToPath(import.meta.url))
 const USER = `${process.env.USER}`
 export const constants = {
     USER: `${USER}`,
@@ -5,4 +10,7 @@ export const constants = {
     HELM: 'helm',
     KIND: 'kind',
     KUBECTL: 'kubectl',
+    CWD: process.cwd(),
+    TMP_DIR: ".fsnetman",
+    RESOURCES_DIR: normalize(CUR_FILE_DIR + "/../../resources")
 }

--- a/fullstack-network-manager/src/core/logging.mjs
+++ b/fullstack-network-manager/src/core/logging.mjs
@@ -64,7 +64,7 @@ export function NewLogger(level = 'debug')  {
             // - Write all logs with importance level of `error` or less to `error.log`
             // - Write all logs with importance level of `info` or less to `combined.log`
             //
-            new winston.transports.File({filename: constants.TMP_DIR + "/logs/combined.log"}),
+            new winston.transports.File({filename: constants.FST_HOME_DIR + "/logs/combined.log"}),
             // new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
             // new winston.transports.Console({format: customFormat})
         ],

--- a/fullstack-network-manager/src/core/logging.mjs
+++ b/fullstack-network-manager/src/core/logging.mjs
@@ -1,5 +1,6 @@
 import * as winston from 'winston'
 import {constants} from "./constants.mjs";
+import * as util from "util";
 
 const customFormat = winston.format.combine(
     winston.format.label({label: 'FST', message: false}),
@@ -34,41 +35,73 @@ const customFormat = winston.format.combine(
     })(),
 )
 
-/**
- * Create a new logger
- * @param level logging level as supported by winston library:
- * {
- *   emerg: 0,
- *   alert: 1,
- *   crit: 2,
- *   error: 3,
- *   warning: 4,
- *   notice: 5,
- *   info: 6,
- *   debug: 7
- * }
- * @returns {winston.Logger}
- * @constructor
- */
-export function NewLogger(level = 'debug')  {
-    let logger = winston.createLogger({
-        level: level,
-        format: winston.format.combine(
-            customFormat,
-            winston.format.json(),
-        ),
-        // format: winston.format.json(),
-        // defaultMeta: { service: 'user-service' },
-        transports: [
-            //
-            // - Write all logs with importance level of `error` or less to `error.log`
-            // - Write all logs with importance level of `info` or less to `combined.log`
-            //
-            new winston.transports.File({filename: constants.FST_HOME_DIR + "/logs/combined.log"}),
-            // new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
-            // new winston.transports.Console({format: customFormat})
-        ],
-    });
+const Logger = class {
+    /**
+     * Create a new logger
+     * @param level logging level as supported by winston library:
+     * {
+     *   emerg: 0,
+     *   alert: 1,
+     *   crit: 2,
+     *   error: 3,
+     *   warning: 4,
+     *   notice: 5,
+     *   info: 6,
+     *   debug: 7
+     * }
+     * @constructor
+     */
+    constructor(level) {
+        this.winsonLogger = winston.createLogger({
+            level: level,
+            format: winston.format.combine(
+                customFormat,
+                winston.format.json(),
+            ),
+            // format: winston.format.json(),
+            // defaultMeta: { service: 'user-service' },
+            transports: [
+                //
+                // - Write all logs with importance level of `error` or less to `error.log`
+                // - Write all logs with importance level of `info` or less to `fst.log`
+                //
+                new winston.transports.File({filename: `${constants.FST_HOME_DIR}/logs/fst.log`}),
+                // new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
+                // new winston.transports.Console({format: customFormat})
+            ],
+        });
+    }
 
-    return logger
+    showUser(msg, ...args) {
+        console.log(util.format(msg, ...args))
+    }
+
+    critical(msg, ...meta) {
+        this.winsonLogger.crit(msg, ...meta)
+    }
+
+    error(msg, ...meta) {
+        this.winsonLogger.error(msg, ...meta)
+        console.trace()
+    }
+
+    warn(msg, ...meta) {
+        this.winsonLogger.warn(msg, ...meta)
+    }
+
+    notice(msg, ...meta) {
+        this.winsonLogger.notice(msg, ...meta)
+    }
+
+    info(msg, ...meta) {
+        this.winsonLogger.info(msg, ...meta)
+    }
+
+    debug(msg, ...meta) {
+        this.winsonLogger.info(msg, ...meta)
+    }
+}
+
+export function NewLogger(level = 'debug')  {
+    return new Logger(level)
 }

--- a/fullstack-network-manager/src/core/logging.mjs
+++ b/fullstack-network-manager/src/core/logging.mjs
@@ -98,7 +98,7 @@ const Logger = class {
     }
 
     debug(msg, ...meta) {
-        this.winsonLogger.info(msg, ...meta)
+        this.winsonLogger.debug(msg, ...meta)
     }
 }
 

--- a/fullstack-network-manager/src/core/logging.mjs
+++ b/fullstack-network-manager/src/core/logging.mjs
@@ -65,7 +65,8 @@ export function NewLogger(level = 'debug')  {
             // - Write all logs with importance level of `info` or less to `combined.log`
             //
             new winston.transports.File({filename: constants.TMP_DIR + "/logs/combined.log"}),
-            new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
+            // new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
+            // new winston.transports.Console({format: customFormat})
         ],
     });
 

--- a/fullstack-network-manager/src/core/logging.mjs
+++ b/fullstack-network-manager/src/core/logging.mjs
@@ -1,4 +1,5 @@
 import * as winston from 'winston'
+import {constants} from "./constants.mjs";
 
 const customFormat = winston.format.combine(
     winston.format.label({label: 'FST', message: false}),
@@ -63,16 +64,10 @@ export function NewLogger(level = 'debug')  {
             // - Write all logs with importance level of `error` or less to `error.log`
             // - Write all logs with importance level of `info` or less to `combined.log`
             //
-            new winston.transports.File({filename: 'combined.log'}),
-            new winston.transports.File({filename: 'error.log', level: 'error'}),
+            new winston.transports.File({filename: constants.TMP_DIR + "/logs/combined.log"}),
+            new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
         ],
     });
-
-    if (process.env.NODE_ENV !== 'production') {
-        logger.add(new winston.transports.Console({
-            format: customFormat,
-        }));
-    }
 
     return logger
 }

--- a/fullstack-network-manager/src/index.mjs
+++ b/fullstack-network-manager/src/index.mjs
@@ -12,12 +12,12 @@ export function main(argv) {
     logger.debug("Constants: %s", JSON.stringify(core.constants))
 
     return yargs(hideBin(argv))
-        .usage('Usage: $0 <command> [options]')
+        .usage(`Usage:\n  $0 <command> [options]`)
         .alias('h', 'help')
         .alias('v', 'version')
         .command(commands.Initialize(opts))
         .strict()
-        .wrap(80)
+        .wrap(120)
         .demand(1, 'Select a command')
         .parse()
 }

--- a/fullstack-network-manager/src/index.mjs
+++ b/fullstack-network-manager/src/index.mjs
@@ -9,6 +9,8 @@ export function main(argv) {
         logger: logger
     }
 
+    logger.debug("Constants: %s", JSON.stringify(core.constants))
+
     return yargs(hideBin(argv))
         .usage('Usage: $0 <command> [options]')
         .alias('h', 'help')


### PR DESCRIPTION
## Description

This pull request changes the following:

- implemented the following commands
    - `cluster create` 
    - `cluster delete`
    - `cluster list`
    - `cluster info`
- create a custom logger and use colored messages
- polish up previously implemented `init` command to show status message to user

Note that the default cluster name is `fst-<USER>`. For example, on my machine it was defaulted to `fst-leninmehedy`

### Usage
```
➜  fsnetman cluster create -h
fsnetman cluster create

Create a cluster

Options:
  -n, --name     Name of the cluster       [string] [default: "fst-leninmehedy"]
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]
➜  fsnetman cluster info -h
fsnetman cluster info

Get cluster info

Options:
  -n, --name     Name of the cluster       [string] [default: "fst-leninmehedy"]
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]
➜  fsnetman cluster list -h
fsnetman cluster list

List all clusters

Options:
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]
➜  fsnetman cluster delete -h
fsnetman cluster delete

Delete a cluster

Options:
  -n, --name     Name of the cluster       [string] [default: "fst-leninmehedy"]
  -h, --help     Show help                                             [boolean]
  -v, --version  Show version number                                   [boolean]


```

### Example Output
```
➜ fsnetman cluster create -n lenin1
Created cluster 'lenin1'

List of clusters
----------------
lenin
lenin1

Kubernetes control plane is running at https://127.0.0.1:61667
CoreDNS is running at https://127.0.0.1:61667/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

➜  fsnetman cluster create
Created cluster 'fst-leninmehedy'

List of clusters
----------------
fst-leninmehedy
lenin
lenin1

Kubernetes control plane is running at https://127.0.0.1:61669
CoreDNS is running at https://127.0.0.1:61669/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

➜ fsnetman cluster list

List of clusters
----------------
fst-leninmehedy
lenin
lenin1

➜ fsnetman cluster info
Kubernetes control plane is running at https://127.0.0.1:61669
CoreDNS is running at https://127.0.0.1:61669/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

➜  fsnetman cluster info -n lenin
Kubernetes control plane is running at https://127.0.0.1:61661
CoreDNS is running at https://127.0.0.1:61661/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.

➜  fsnetman cluster delete
Deleting cluster 'fst-leninmehedy'

List of clusters
----------------
lenin
lenin1

Deleted cluster 'fst-leninmehedy'
➜  fsnetman cluster delete -n lenin
Deleting cluster 'lenin'

List of clusters
----------------
lenin1

Deleted cluster 'lenin'
```

### Related Issues

- Closes #432 
