### PR TITLE
fix(cli): encapsulate helm and kubectl commands and code cleanup

### DIFF
--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -10,7 +10,7 @@ export class BaseCommand extends ShellRunner {
             this.logger.debug(cmd)
             await this.run(cmd)
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
             return false
         }
 
@@ -80,7 +80,7 @@ export class BaseCommand extends ShellRunner {
         try {
             return await this.helm.list(`-n ${namespaceName}`, '-q')
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return []
@@ -88,11 +88,13 @@ export class BaseCommand extends ShellRunner {
 
     async chartInstall(namespaceName, chartName, chartPath, valuesArg = '') {
         try {
-            this.logger.showUser(chalk.cyan('> checking chart:'), chalk.yellow(`${chartName}`))
             let charts = await this.getInstalledCharts(namespaceName)
             if (!charts.includes(chartName)) {
+                this.logger.showUser(chalk.cyan('> running helm dependency update for chart:'), chalk.yellow(`${chartName} ...`))
+                await this.helm.dependency('update', chartPath)
+
                 this.logger.showUser(chalk.cyan('> installing chart:'), chalk.yellow(`${chartName}`))
-                this.helm.install(`-n ${namespaceName} ${chartName} ${chartPath} ${valuesArg}`)
+                await this.helm.install(`-n ${namespaceName} ${chartName} ${chartPath} ${valuesArg}`)
                 this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is installed`)
             } else {
                 this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is already installed`)
@@ -100,7 +102,7 @@ export class BaseCommand extends ShellRunner {
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false
@@ -112,7 +114,7 @@ export class BaseCommand extends ShellRunner {
             let charts = await this.getInstalledCharts(namespaceName)
             if (charts.includes(chartName)) {
                 this.logger.showUser(chalk.cyan('> uninstalling chart:'), chalk.yellow(`${chartName}`))
-                this.helm.uninstall(`-n ${namespaceName} ${chartName}`)
+                await this.helm.uninstall(`-n ${namespaceName} ${chartName}`)
                 this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is uninstalled`)
             } else {
                 this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is already uninstalled`)
@@ -120,7 +122,7 @@ export class BaseCommand extends ShellRunner {
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false
@@ -129,12 +131,12 @@ export class BaseCommand extends ShellRunner {
     async chartUpgrade(namespaceName, chartName, chartPath, valuesArg = '') {
         try {
             this.logger.showUser(chalk.cyan('> upgrading chart:'), chalk.yellow(`${chartName}`))
-            this.helm.upgrade(`-n ${namespaceName} ${chartName} ${chartPath} ${valuesArg}`)
+            await this.helm.upgrade(`-n ${namespaceName} ${chartName} ${chartPath} ${valuesArg}`)
             this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is upgraded`)
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false

--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -10,12 +10,13 @@ export class BaseCommand extends ShellRunner {
             this.logger.debug(cmd)
             await this.run(cmd)
         } catch (e) {
-            this.logger.error("%s", e)
+            this.logger.showUserError(err)
             return false
         }
 
         return true
     }
+
     /**
      * Check if 'kind' CLI program is installed or not
      * @returns {Promise<boolean>}
@@ -77,104 +78,78 @@ export class BaseCommand extends ShellRunner {
      */
     async getInstalledCharts(namespaceName) {
         try {
-            let cmd = `helm list -n ${namespaceName} -q`
-
-            let output = await this.run(cmd)
-            this.logger.showUser("\nList of installed charts\n--------------------------\n%s", output)
-
-            return output.split(/\r?\n/)
+            return await this.helm.list(`-n ${namespaceName}`, '-q')
         } catch (e) {
-            this.logger.error("%s", e)
-            this.logger.showUser(e.message)
+            this.logger.showUserError(err)
         }
 
         return []
     }
 
-    async chartInstall(namespaceName, releaseName, chartPath, valuesArg) {
+    async chartInstall(namespaceName, chartName, chartPath, valuesArg = '') {
         try {
-            this.logger.showUser(chalk.cyan(`Setting up FST network...`))
-
-            let charts= await this.getInstalledCharts(namespaceName)
-            if (!charts.includes(releaseName)) {
-                let cmd = `helm install -n ${namespaceName} ${releaseName} ${chartPath} ${valuesArg}`
-                this.logger.showUser(chalk.cyan(`Installing ${releaseName} chart`))
-
-                let output = await this.run(cmd)
-                this.logger.showUser(chalk.green('OK'), `chart '${releaseName}' is installed`)
+            this.logger.showUser(chalk.cyan('> checking chart:'), chalk.yellow(`${chartName}`))
+            let charts = await this.getInstalledCharts(namespaceName)
+            if (!charts.includes(chartName)) {
+                this.logger.showUser(chalk.cyan('> installing chart:'), chalk.yellow(`${chartName}`))
+                this.helm.install(`-n ${namespaceName} ${chartName} ${chartPath} ${valuesArg}`)
+                this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is installed`)
             } else {
-                this.logger.showUser(chalk.green('OK'), `chart '${releaseName}' is already installed`)
+                this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is already installed`)
             }
-
-            this.logger.showUser(chalk.yellow("Chart setup is complete"))
 
             return true
         } catch (e) {
-            this.logger.error("%s", e.stack)
-            this.logger.showUser(e.message)
+            this.logger.showUserError(err)
         }
 
         return false
     }
 
-    async chartUninstall(namespaceName, releaseName) {
+    async chartUninstall(namespaceName, chartName) {
         try {
-            this.logger.showUser(chalk.cyan(`Uninstalling FST network ...`))
-
-            let charts= await this.getInstalledCharts(namespaceName)
-            if (charts.includes(releaseName)) {
-                let cmd = `helm uninstall ${releaseName} -n ${namespaceName}`
-                this.logger.showUser(chalk.cyan(`Uninstalling ${releaseName} chart`))
-
-                let output = await this.run(cmd)
-                this.logger.showUser(chalk.green('OK'), `chart '${releaseName}' is uninstalled`)
-                await this.getInstalledCharts(namespaceName)
+            this.logger.showUser(chalk.cyan('> checking chart:'), chalk.yellow(`${chartName}`))
+            let charts = await this.getInstalledCharts(namespaceName)
+            if (charts.includes(chartName)) {
+                this.logger.showUser(chalk.cyan('> uninstalling chart:'), chalk.yellow(`${chartName}`))
+                this.helm.uninstall(`-n ${namespaceName} ${chartName}`)
+                this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is uninstalled`)
             } else {
-                this.logger.showUser(chalk.green('OK'), `chart '${releaseName}' is already uninstalled`)
+                this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is already uninstalled`)
             }
-
-            this.logger.showUser(chalk.yellow("Chart uninstallation is complete"))
 
             return true
         } catch (e) {
-            this.logger.error("%s", e.stack)
-            this.logger.showUser(e.message)
+            this.logger.showUserError(err)
         }
 
         return false
     }
 
-    async chartUpgrade(namespaceName, releaseName, chartPath, valuesArg) {
+    async chartUpgrade(namespaceName, chartName, chartPath, valuesArg = '') {
         try {
-            this.logger.showUser(chalk.cyan(`Upgrading FST network deployment chart ...`))
-
-            let charts= await this.getInstalledCharts(namespaceName)
-            if (charts.includes(releaseName)) {
-                let cmd = `helm upgrade ${releaseName} -n ${namespaceName} ${chartPath} ${valuesArg}`
-                this.logger.showUser(chalk.cyan(`Upgrading ${releaseName} chart`))
-
-                let output = await this.run(cmd)
-                this.logger.showUser(chalk.green('OK'), `chart '${releaseName}' is upgraded`)
-                await this.getInstalledCharts(namespaceName)
-
-                this.logger.showUser(chalk.yellow("Chart upgrade is complete"))
-            } else {
-                this.logger.showUser(chalk.green('OK'), `chart '${releaseName}' is not installed`)
-                return false
-            }
+            this.logger.showUser(chalk.cyan('> upgrading chart:'), chalk.yellow(`${chartName}`))
+            this.helm.upgrade(`-n ${namespaceName} ${chartName} ${chartPath} ${valuesArg}`)
+            this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is upgraded`)
 
             return true
         } catch (e) {
-            this.logger.error("%s", e.stack)
-            this.logger.showUser(e.message)
+            this.logger.showUserError(err)
         }
 
         return false
     }
-
 
     constructor(opts) {
         super(opts);
+
+        if (!opts || !opts.kind) throw new Error('An instance of core/Kind is required')
+        if (!opts || !opts.helm) throw new Error('An instance of core/Helm is required')
+        if (!opts || !opts.kubectl) throw new Error('An instance of core/Kubectl is required')
+
+        this.kind = opts.kind
+        this.helm = opts.helm
+        this.kubectl = opts.kubectl
 
         // map of dependency checks
         this.checks = new Map()

--- a/fullstack-network-manager/src/commands/chart.mjs
+++ b/fullstack-network-manager/src/commands/chart.mjs
@@ -25,7 +25,7 @@ export class ChartCommand extends BaseCommand {
         let namespace = argv.namespace
         let valuesArg = this.prepareValuesArg(argv)
 
-        await this.run(`helm dependency update ${this.chartPath}`)
+        await this.helm.dependency('update', this.chartPath)
         return await this.chartInstall(namespace, this.releaseName, this.chartPath, valuesArg)
     }
 

--- a/fullstack-network-manager/src/commands/chart.mjs
+++ b/fullstack-network-manager/src/commands/chart.mjs
@@ -6,7 +6,7 @@ import * as flags from "./flags.mjs";
 
 export class ChartCommand extends BaseCommand {
     chartPath = `${core.constants.FST_HOME_DIR}/full-stack-testing/charts/fullstack-deployment`
-    releaseName = "fullstack-deployment"
+    chartName = "fullstack-deployment"
 
     prepareValuesArg(argv) {
         let {valuesFile, mirrorNode, hederaExplorer} = argv
@@ -25,21 +25,20 @@ export class ChartCommand extends BaseCommand {
         let namespace = argv.namespace
         let valuesArg = this.prepareValuesArg(argv)
 
-        await this.helm.dependency('update', this.chartPath)
-        return await this.chartInstall(namespace, this.releaseName, this.chartPath, valuesArg)
+        return await this.chartInstall(namespace, this.chartName, this.chartPath, valuesArg)
     }
 
     async uninstall(argv) {
         let namespace = argv.namespace
 
-        return await this.chartUninstall(namespace, this.releaseName)
+        return await this.chartUninstall(namespace, this.chartName)
     }
 
     async upgrade(argv) {
         let namespace = argv.namespace
         let valuesArg = this.prepareValuesArg(argv)
 
-        return await this.chartUpgrade(namespace, this.releaseName, this.chartPath, valuesArg)
+        return await this.chartUpgrade(namespace, this.chartName, this.chartPath, valuesArg)
     }
 
     static getCommandDefinition(chartCmd) {

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -16,7 +16,7 @@ export class ClusterCommand extends BaseCommand {
         try {
             return await this.kind.getClusters('-q')
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return []
@@ -48,7 +48,7 @@ export class ClusterCommand extends BaseCommand {
         try {
             return await this.kubectl.getNamespace(`--no-headers`, `-o name`)
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return []
@@ -71,7 +71,7 @@ export class ClusterCommand extends BaseCommand {
             this.logger.showUser("\n")
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false
@@ -86,7 +86,7 @@ export class ClusterCommand extends BaseCommand {
                 this.logger.showUser(chalk.cyan('> creating namespace:'), chalk.yellow(`${namespace} ...`))
                 await this.kubectl.createNamespace(namespace)
                 this.logger.showUser(chalk.green('OK'), `namespace '${namespace}' is created`)
-            } {
+            } else {
                 this.logger.showUser(chalk.green('OK'), `namespace '${namespace}' already exists`)
             }
 
@@ -94,7 +94,7 @@ export class ClusterCommand extends BaseCommand {
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false
@@ -131,27 +131,7 @@ export class ClusterCommand extends BaseCommand {
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
-        }
-
-        return false
-    }
-
-    async deleteNamespace(argv) {
-        try {
-            let namespace = argv.namespace
-            let namespaces = await this.getNameSpaces()
-            if (namespaces.includes(namespace)) {
-                this.logger.showUser(chalk.cyan('Deleting namespace:'), chalk.yellow(`${namespaces}...`))
-                await this.kubectl.deleteNamespace(namespace)
-                this.logger.showUser(chalk.green('Deleted namespace:'), chalk.yellow(namespaces))
-            }
-
-            this.showList("namespaces", await this.getNameSpaces())
-
-            return true
-        } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false
@@ -179,7 +159,7 @@ export class ClusterCommand extends BaseCommand {
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false
@@ -187,7 +167,7 @@ export class ClusterCommand extends BaseCommand {
 
 
     async showInstalledChartList(namespace) {
-        this.showList("charts installed", await this.getInstalledCharts(namespace) )
+        this.showList("charts installed", await this.getInstalledCharts(namespace))
     }
 
     /**
@@ -211,7 +191,7 @@ export class ClusterCommand extends BaseCommand {
 
             return true
         } catch (e) {
-            this.logger.showUserError(err)
+            this.logger.showUserError(e)
         }
 
         return false

--- a/fullstack-network-manager/src/core/helm.mjs
+++ b/fullstack-network-manager/src/core/helm.mjs
@@ -23,6 +23,24 @@ export class Helm extends ShellRunner {
     }
 
     /**
+     * Invoke `helm uninstall` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async uninstall(...args) {
+        return this.run(this.prepareCommand('uninstall', ...args))
+    }
+
+    /**
+     * Invoke `helm upgrade` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async upgrade(...args) {
+        return this.run(this.prepareCommand('upgrade', ...args))
+    }
+
+    /**
      * Invoke `helm list` command
      * @param args args of the command
      * @returns {Promise<Array>} console output as an array of strings

--- a/fullstack-network-manager/src/core/helm.mjs
+++ b/fullstack-network-manager/src/core/helm.mjs
@@ -1,0 +1,43 @@
+import {ShellRunner} from "./shell_runner.mjs";
+
+export class Helm extends ShellRunner {
+    /**
+     * Prepare a `helm` shell command string
+     * @param action represents a helm command (e.g. create | install | get )
+     * @param args args of the command
+     * @returns {string}
+     */
+    prepareCommand(action, ...args) {
+        let cmd = `helm ${action} `
+        args.forEach(arg => {cmd += ` ${arg}`})
+        return cmd
+    }
+
+    /**
+     * Invoke `helm install` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async install(...args) {
+        return this.run(this.prepareCommand('install', ...args))
+    }
+
+    /**
+     * Invoke `helm list` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async list(...args) {
+        return this.run(this.prepareCommand('list', ...args))
+    }
+
+    /**
+     * Invoke `helm dependency` command
+     * @param subCommand sub-command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async dependency(subCommand,...args) {
+        return this.run(this.prepareCommand('dependency', subCommand, ...args))
+    }
+}

--- a/fullstack-network-manager/src/core/index.mjs
+++ b/fullstack-network-manager/src/core/index.mjs
@@ -1,5 +1,8 @@
 import * as logging from './logging.mjs'
 import {constants} from './constants.mjs'
+import {Kind} from './kind.mjs'
+import {Helm} from './helm.mjs'
+import {Kubectl} from "./kubectl.mjs";
 
 // Expose components from the core module
-export {logging, constants}
+export {logging, constants, Kind, Helm, Kubectl}

--- a/fullstack-network-manager/src/core/kubectl.mjs
+++ b/fullstack-network-manager/src/core/kubectl.mjs
@@ -1,0 +1,72 @@
+import {ShellRunner} from "./shell_runner.mjs";
+
+export class Kubectl extends ShellRunner {
+    /**
+     * Prepare a `kubectl` shell command string
+     * @param action represents a helm command (e.g. create | install | get )
+     * @param args args of the command
+     * @returns {string}
+     */
+    prepareCommand(action, ...args) {
+        let cmd = `kubectl ${action} `
+        args.forEach(arg => {cmd += ` ${arg}`})
+        return cmd
+    }
+
+    /**
+     * Invoke `kubectl create` command
+     * @param resource a kubernetes resource type (e.g. pod | svc etc.)
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async create(resource, ...args) {
+        return this.run(this.prepareCommand('create', resource, ...args))
+    }
+
+    /**
+     * Invoke `kubectl create ns` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async createNamespace(...args) {
+        return this.run(this.prepareCommand('create', 'ns', ...args))
+    }
+
+    /**
+     * Invoke `kubectl delete` command
+     * @param resource a kubernetes resource type (e.g. pod | svc etc.)
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async delete(resource, ...args) {
+        return this.run(this.prepareCommand('delete', resource, ...args))
+    }
+
+    /**
+     * Invoke `kubectl delete ns` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async deleteNamespace(...args) {
+        return this.run(this.prepareCommand('delete', 'ns', ...args))
+    }
+
+    /**
+     * Invoke `kubectl get` command
+     * @param resource a kubernetes resource type (e.g. pod | svc etc.)
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async get(resource, ...args) {
+        return this.run(this.prepareCommand('get', resource, ...args))
+    }
+
+    /**
+     * Invoke `kubectl get ns` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async getNamespace(...args) {
+        return this.run(this.prepareCommand('get', 'ns', ...args))
+    }
+}

--- a/fullstack-network-manager/src/core/logging.mjs
+++ b/fullstack-network-manager/src/core/logging.mjs
@@ -2,6 +2,7 @@ import * as winston from 'winston'
 import {constants} from "./constants.mjs";
 import {v4 as uuidv4} from 'uuid';
 import * as util from "util";
+import chalk from "chalk";
 
 const customFormat = winston.format.combine(
     winston.format.label({label: 'FST', message: false}),
@@ -91,6 +92,10 @@ const Logger = class {
 
     showUser(msg, ...args) {
         console.log(util.format(msg, ...args))
+    }
+    showUserError(err) {
+        console.log(chalk.red(err.message))
+        console.log(err.stack)
     }
 
     critical(msg, ...args) {

--- a/fullstack-network-manager/src/core/shell_runner.mjs
+++ b/fullstack-network-manager/src/core/shell_runner.mjs
@@ -2,7 +2,7 @@ import {spawn} from "child_process";
 
 export class ShellRunner {
     constructor(opts) {
-        if (!opts || !opts.logger === undefined) throw new Error("logger must be provided")
+        if (!opts || !opts.logger === undefined) throw new Error("An instance of core/Logger is required")
         this.logger = opts.logger
     }
 

--- a/fullstack-network-manager/src/index.mjs
+++ b/fullstack-network-manager/src/index.mjs
@@ -5,8 +5,15 @@ import * as core from './core/index.mjs'
 
 export function main(argv) {
     const logger = core.logging.NewLogger('debug')
+    const kind = new core.Kind({logger: logger})
+    const helm = new core.Helm({logger: logger})
+    const kubectl= new core.Kubectl({logger: logger})
+
     const opts = {
-        logger: logger
+        logger: logger,
+        kind: kind,
+        helm: helm,
+        kubectl: kubectl,
     }
 
     logger.debug("Constants: %s", JSON.stringify(core.constants))

--- a/fullstack-network-manager/test/commands/base.test.js
+++ b/fullstack-network-manager/test/commands/base.test.js
@@ -1,5 +1,5 @@
 import {test, expect, it, describe} from "@jest/globals";
-import {logging} from "../../src/core/index.mjs";
+import {Helm, Kubectl, logging} from "../../src/core/index.mjs";
 import {BaseCommand} from "../../src/commands/base.mjs";
 import * as core from "../../src/core/index.mjs"
 import {Kind} from "../../src/core/kind.mjs";
@@ -8,9 +8,13 @@ const testLogger = logging.NewLogger("debug")
 
 describe('BaseCommand', () => {
     const kind = new Kind({logger: testLogger})
+    const helm = new Helm({logger: testLogger})
+    const kubectl = new Kubectl({logger: testLogger})
     const baseCmd = new BaseCommand({
         logger: testLogger,
         kind: kind,
+        helm: helm,
+        kubectl: kubectl,
     })
 
     describe('runShell', () => {

--- a/fullstack-network-manager/test/commands/base.test.js
+++ b/fullstack-network-manager/test/commands/base.test.js
@@ -2,11 +2,16 @@ import {test, expect, it, describe} from "@jest/globals";
 import {logging} from "../../src/core/index.mjs";
 import {BaseCommand} from "../../src/commands/base.mjs";
 import * as core from "../../src/core/index.mjs"
+import {Kind} from "../../src/core/kind.mjs";
 
 const testLogger = logging.NewLogger("debug")
 
 describe('BaseCommand', () => {
-    const baseCmd = new BaseCommand({logger: testLogger})
+    const kind = new Kind({logger: testLogger})
+    const baseCmd = new BaseCommand({
+        logger: testLogger,
+        kind: kind,
+    })
 
     describe('runShell', () => {
         it('should fail during invalid program check', async() => {

--- a/fullstack-network-manager/test/commands/init.test.js
+++ b/fullstack-network-manager/test/commands/init.test.js
@@ -1,10 +1,20 @@
 import {InitCommand} from "../../src/commands/init.mjs";
 import {expect, describe, it} from "@jest/globals";
 import * as core  from "../../src/core/index.mjs";
+import {Helm, Kind, Kubectl} from "../../src/core/index.mjs";
+import {BaseCommand} from "../../src/commands/base.mjs";
 
 const testLogger = core.logging.NewLogger('debug')
 describe('InitCommand', () => {
-    const initCmd = new InitCommand({logger: testLogger})
+    const kind = new Kind({logger: testLogger})
+    const helm = new Helm({logger: testLogger})
+    const kubectl = new Kubectl({logger: testLogger})
+    const initCmd = new InitCommand({
+        logger: testLogger,
+        kind: kind,
+        helm: helm,
+        kubectl: kubectl,
+    })
 
     describe('commands', () => {
         it('init execution should succeed', async () => {


### PR DESCRIPTION
## Description

This pull request changes the following:

- encapsulate helm and kubectl commands
- polish `cluster` commands
- polish `chart` commands
- apply colors in console messages for clarity
### Related Issues

- Closes #469 
