### PR TITLE
bug: set fullstack-cluster-setup to default true in fsnetman for installing minio & prometheus-stack

### DIFF
--- a/charts/fullstack-cluster-setup/values.yaml
+++ b/charts/fullstack-cluster-setup/values.yaml
@@ -10,8 +10,8 @@ global:
 # cloud configuration
 cloud:
   minio:
-    enabled: true
+    enabled: false
   prometheusStack:
-    enabled: true
+    enabled: false
   grafanaAgent:
     enabled: false

--- a/charts/fullstack-cluster-setup/values.yaml
+++ b/charts/fullstack-cluster-setup/values.yaml
@@ -10,8 +10,8 @@ global:
 # cloud configuration
 cloud:
   minio:
-    enabled: false
+    enabled: true
   prometheusStack:
-    enabled: false
+    enabled: true
   grafanaAgent:
     enabled: false

--- a/fullstack-network-manager/README.md
+++ b/fullstack-network-manager/README.md
@@ -8,7 +8,7 @@ fullstack-network-manager is a CLI tool to manage and deploy a Hedera Network us
 ❯ cat ~/.npmrc
 @hashgraph:registry=https://npm.pkg.github.com
 ```
-- Run `nmp install -g @hedera/fullstack-network-manager`
+- Run `npm install -g @hedera/fullstack-network-manager`
 
 - Run `fsnetman` from a terminal as shown below
 ``` 

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -184,9 +184,10 @@ export class ClusterCommand extends BaseCommand {
             let chartName = "fullstack-cluster-setup"
             let namespace = argv.namespace
             let chartPath = `${core.constants.FST_HOME_DIR}/full-stack-testing/charts/${chartName}`
+            let valuesArg = this.prepareValuesArg(argv)
 
             this.logger.showUser(chalk.cyan('> setting up cluster:'), chalk.yellow(`${clusterName}`))
-            await this.chartInstall(namespace, chartName, chartPath)
+            await this.chartInstall(namespace, chartName, chartPath, valuesArg)
             await this.showInstalledChartList(namespace)
 
             return true
@@ -283,6 +284,8 @@ export class ClusterCommand extends BaseCommand {
                         builder: yargs => {
                             yargs.option('cluster-name', flags.clusterNameFlag)
                             yargs.option('namespace', flags.namespaceFlag)
+                            yargs.option('prometheus-stack', flags.deployPrometheusStack)
+                            yargs.option('minio', flags.deployMinio)
                         },
                         handler: argv => {
                             clusterCmd.logger.debug("==== Running 'cluster setup' ===")
@@ -299,5 +302,10 @@ export class ClusterCommand extends BaseCommand {
                     .demand(1, 'Select a cluster command')
             }
         }
+    }
+
+    prepareValuesArg(argv) {
+        let {prometheusStack, minio} = argv
+        return ` --set cloud.prometheusStack.enabled=${prometheusStack} --set cloud.minio.enabled=${minio}`
     }
 }

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -184,7 +184,7 @@ export class ClusterCommand extends BaseCommand {
             let chartName = "fullstack-cluster-setup"
             let namespace = argv.namespace
             let chartPath = `${core.constants.FST_HOME_DIR}/full-stack-testing/charts/${chartName}`
-            let valuesArg = this.prepareValuesArg(argv)
+            let valuesArg = this.prepareValuesArg(argv.prometheusStack, argv.minio)
 
             this.logger.showUser(chalk.cyan('> setting up cluster:'), chalk.yellow(`${clusterName}`))
             await this.chartInstall(namespace, chartName, chartPath, valuesArg)

--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -304,8 +304,7 @@ export class ClusterCommand extends BaseCommand {
         }
     }
 
-    prepareValuesArg(argv) {
-        let {prometheusStack, minio} = argv
-        return ` --set cloud.prometheusStack.enabled=${prometheusStack} --set cloud.minio.enabled=${minio}`
+    prepareValuesArg(prometheusStackEnabled, minioEnabled) {
+        return ` --set cloud.prometheusStack.enabled=${prometheusStackEnabled} --set cloud.minio.enabled=${minioEnabled}`
     }
 }

--- a/fullstack-network-manager/src/commands/flags.mjs
+++ b/fullstack-network-manager/src/commands/flags.mjs
@@ -35,3 +35,17 @@ export const valuesFile = {
     alias: 'f',
     type: 'string'
 }
+
+export const deployPrometheusStack = {
+    describe: 'Deploy prometheus stack',
+    default: true,
+    alias: 'p',
+    type: 'boolean'
+}
+
+export const deployMinio = {
+    describe: 'Deploy minio operator',
+    default: true,
+    alias: 'o',
+    type: 'boolean'
+}


### PR DESCRIPTION
## Description

This pull request changes the following:

- set fullstack-cluster-setup to default true in fsnetman for installing minio & prometheus-stack

### Related Issues

- Closes #475

NOTE: for #475 to work without any additional commands, #473 needs to be closed.
