### PR TITLE
chore: add support for publishing helm chart to github pages

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -46,6 +46,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: write
+  packages: write
+  pages: write
+
 jobs:
   prepare-release:
     name: Release / Prepare
@@ -71,6 +76,7 @@ jobs:
 
       - name: Calculate Next Version
         env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
@@ -80,10 +86,7 @@ jobs:
 
       - name: Extract Version
         id: tag
-        run: |
-          cat VERSION
-          [[ ! -f VERSION ]] && echo "VERSION file is not found" && exit 1  # error on missing VERSION file
-          echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
+        run: echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
 
   publish-maven-central:
     name: Publish
@@ -94,8 +97,8 @@ jobs:
       custom-job-label: Maven Central
       new-version: ${{ needs.prepare-release.outputs.version }}
       dry-run-enabled: ${{ github.event.inputs.dry-run-enabled == 'true' }}
-      java-distribution: ${{ github.event.inputs.java-distribution || '17.0.7' }}
-      java-version: ${{ github.event.inputs.java-version || 'temurin' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      java-version: ${{ github.event.inputs.java-version || '17.0.7' }}
       gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
     secrets:
       gpg-key-contents: ${{ secrets.GPG_KEY_CONTENTS }}
@@ -157,26 +160,43 @@ jobs:
           push: ${{ github.event.inputs.dry-run-enabled != 'true' }}
           tags: ghcr.io/${{ github.repository }}/kubectl-bats:${{ needs.prepare-release.outputs.version }}
 
-  publish-npm-packages:
-    name: Publish / NPM Packages
+  publish-helm-charts:
+    name: Publish / Helm Charts
     runs-on: [self-hosted, Linux, medium, ephemeral]
     needs:
       - prepare-release
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Install Node
-        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+
+      - name: Setup Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          node-version: 18
-      - name: Publish NPM Package
-        working-directory: "fullstack-network-manager"
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npm ci 
-          npm i replace-json-property && ./node_modules/replace-json-property/bin/replace-json-property.bin.js package.json version ${{ needs.prepare-release.outputs.version }} && cat package.json | grep 'version'
-          npm publish ${{ github.event.inputs.dry-run-enabled && '--dry-run' || '' }}
+          version: "v3.12.3" # helm version
+
+      - name: Setup Java
+        uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
+        with:
+          distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+          java-version: ${{ github.event.inputs.java-version || '17.0.7' }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
+
+      - name: Apply Version Number Update (Explicit)
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2.9.0
+        with:
+          gradle-version: ${{ github.event.inputs.gradle-version || 'wrapper' }}
+          arguments: versionAsSpecified --scan -PnewVersion=${{ needs.prepare-release.outputs.version }}
+
+      - name: Publish Helm Charts
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 #v1.7.0
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target_dir: charts
 
   create-github-release:
     name: Github / Release
@@ -184,7 +204,7 @@ jobs:
     needs:
       - publish-maven-central
       - publish-docker-image
-      - publish-npm-packages
+      - publish-helm-charts
     if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
     steps:
       - name: Checkout Code
@@ -243,6 +263,7 @@ jobs:
 
       - name: Publish Semantic Release
         env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}

--- a/.releaserc
+++ b/.releaserc
@@ -8,7 +8,13 @@
       }
     ],
     "@semantic-release/git",
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@semantic-release/npm",
+      {
+        "pkgRoot": "fullstack-network-manager"
+      }
+    ]
   ],
   "verifyRelease": [
     [

--- a/fullstack-network-manager/.npmrc
+++ b/fullstack-network-manager/.npmrc
@@ -1,2 +1,2 @@
-//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}
+//npm.pkg.github.com/:_authToken=${NPM_TOKEN}
 @hashgraph:registry=https://npm.pkg.github.com


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for publishing helm charts to github pages
- Streamlines NPM package releases by using the `@semantic-release/npm`  plugin

### Related Issues

- Closes #459 
