### PR TITLE
bug: add permission required to run maven publish workflow

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -50,6 +50,7 @@ permissions:
   contents: write
   packages: write
   pages: write
+  id-token: write
 
 jobs:
   prepare-release:


### PR DESCRIPTION
## Description

This pull request changes the following:

- fix permission issue in [flow-deploy-release-artifact.yaml](https://github.com/hashgraph/full-stack-testing/compare/bug-wf-break?expand=1#diff-f1bcd1ef387efde297c1469d5f2c6ed7ba81f38b14e3d54d270914d1125bb2cc)

### Related Issues

- Closes #
