### PR TITLE
fix: set namespace to kubectl context after cluster create

### DIFF
--- a/fullstack-network-manager/src/commands/cluster.mjs
+++ b/fullstack-network-manager/src/commands/cluster.mjs
@@ -89,7 +89,7 @@ export class ClusterCommand extends BaseCommand {
                 this.logger.showUser(chalk.green('OK'), `namespace '${namespace}' already exists`)
             }
 
-            // TODO: kubectl config set-context --current --namespace="${NAMESPACE}"
+            await this.kubectl.config(`set-context --current --namespace="${namespace}"`)
 
             this.showList("namespaces", await this.getNameSpaces())
 

--- a/fullstack-network-manager/src/core/kubectl.mjs
+++ b/fullstack-network-manager/src/core/kubectl.mjs
@@ -146,4 +146,13 @@ export class Kubectl extends ShellRunner {
     async copy(pod, ...args) {
         return this.run(this.prepareCommand('cp', ...args))
     }
+
+    /**
+     * Invoke `kubectl config` command
+     * @param args args of the command
+     * @returns {Promise<Array>} console output as an array of strings
+     */
+    async config(...args) {
+        return this.run(this.prepareCommand('config', ...args))
+    }
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

- set namespace to kubectl context after cluster create

### Related Issues

- Closes #519 
