### PR TITLE
fix(cli): kubectl version command errors out if server is un reachable

### DIFF
--- a/fullstack-network-manager/src/commands/base.mjs
+++ b/fullstack-network-manager/src/commands/base.mjs
@@ -37,7 +37,7 @@ export class BaseCommand extends ShellRunner {
      * @returns {Promise<boolean>}
      */
     async checkKubectl() {
-        return this.checkDep(`${core.constants.KUBECTL} version`)
+        return this.checkDep(`${core.constants.KUBECTL} version --client`)
     }
 
     /**


### PR DESCRIPTION
## Description

This pull request changes the following:

- In `fstnetman init` dependency check should make use of `kubectl version --client`,
  without this if a k8s server in default context is not reachable it fails with an error
  and falsely reports that 'kubectl' is not found

### Related Issues

- Closes #530 
