### PR TITLE
feat(cli): allow deploying different number network nodes

### DIFF
--- a/.github/workflows/zxc-helm-chart-tests.yaml
+++ b/.github/workflows/zxc-helm-chart-tests.yaml
@@ -82,7 +82,7 @@ jobs:
             echo " - ${file} was changed"
           done
           echo ""
-          if [ "${{ steps.changed-files.outputs.scripts_any_changed }}" ] || [ "${{ steps.changed-files.outputs.scripts_any_changed }}" ]; then
+          if [ "${{ steps.changed-files.outputs.scripts_any_changed }}" == "true" ]; then
             echo "run-tests=true" >> "${GITHUB_OUTPUT}"
             echo "Executing helm chart tests...."
           else

--- a/docker/ubi8-init-java21/entrypoint.sh
+++ b/docker/ubi8-init-java21/entrypoint.sh
@@ -104,6 +104,7 @@ echo
 
 set +e
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> BEGIN NODE OUTPUT >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
+echo "command: /usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp """${JAVA_CLASS_PATH}""" """${JAVA_MAIN_CLASS}""""
 /usr/bin/env java ${JAVA_HEAP_OPTS} ${JAVA_OPTS} -cp "${JAVA_CLASS_PATH}" "${JAVA_MAIN_CLASS}"
 EC="${?}"
 echo "<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< END NODE OUTPUT   <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<"

--- a/solo/README.md
+++ b/solo/README.md
@@ -43,8 +43,10 @@ $ kubectx <context-name>
 ```
 $ export SOLO_CLUSTER_NAME=solo
 $ export SOLO_NAMESPACE=solo
+$ export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
 $ kind create cluster -n "${SOLO_CLUSTER_NAME}" 
 $ kubectl create ns "${SOLO_NAMESPACE}" 
+$ kubectl create ns "${SOLO_CLUSTER_SETUP_NAMESPACE}"
 
 Creating cluster "solo" ...
  ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
@@ -118,7 +120,7 @@ You may run `solo node keys --gossip-keys --tls-keys --key-format pem -i node0,n
 * Initialize `solo` with tag `v0.42.5` and list of node names `node0,node1,node2`:
 
 ```
-$ solo init -t v0.42.5 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
+$ solo init -t v0.42.5 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" 
 
 ******************************* Solo *********************************************
 Version                 : 0.19.1
@@ -147,7 +149,7 @@ hedera-node0.key  hedera-node1.key  hedera-node2.key  private-node1.pfx public.p
 
 ```
 
-* Setup cluster with shared components (by default it is installed in the `default` namespace)
+* Setup cluster with shared components
 
 ```
 $ solo cluster setup
@@ -270,43 +272,43 @@ Kubernetes Namespace    : solo
 You may view the list of pods using `k9s` as below:
 
 ```
- Context: kind-solo                                <0> all       <a>      Attach     <l>       Logs               ____  __.________
- Cluster: kind-solo                                <1> default   <ctrl-d> Delete     <p>       Logs Previous     |    |/ _/   __   \______
- User:    kind-solo                                              <d>      Describe   <shift-f> Port-Forward      |      < \____    /  ___/
- K9s Rev: v0.27.4 ⚡️v0.31.7                                      <e>      Edit       <s>       Shell             |    |  \   /    /\___ \
- K8s Rev: v1.27.3                                                <?>      Help       <n>       Show Node         |____|__ \ /____//____  >
- CPU:     n/a                                                    <ctrl-k> Kill       <f>       Show PortForward          \/            \/
+ Context: kind-solo ✏️                              <0> all       <a>      Attach     <l>       Logs            <f> Show PortForward                                                        ____  __.________
+ Cluster: kind-solo                                <1> default   <ctrl-d> Delete     <p>       Logs Previous   <t> Transfer                                                               |    |/ _/   __   \______
+ User:    kind-solo                                              <d>      Describe   <shift-f> Port-Forward    <y> YAML                                                                   |      < \____    /  ___/
+ K9s Rev: v0.31.7                                                <e>      Edit       <z>       Sanitize                                                                                   |    |  \   /    /\___ \
+ K8s Rev: v1.27.3                                                <?>      Help       <s>       Shell                                                                                      |____|__ \ /____//____  >
+ CPU:     n/a                                                    <ctrl-k> Kill       <n>       Show Node                                                                                          \/            \/
  MEM:     n/a
-┌───────────────────────────────────────────────────────────── Pods(all)[27] ─────────────────────────────────────────────────────────────┐
-│ NAMESPACE↑          NAME                                                   PF READY RESTARTS STATUS   IP           NODE                 │
-│ default             console-557956d575-4tph9                               ●  1/1          0 Running  10.244.0.6   solo-control-plane   │
-│ default             minio-operator-7d575c5f84-mkk8t                        ●  1/1          0 Running  10.244.0.5   solo-control-plane   │
-│ kube-system         coredns-5d78c9869d-8x4zm                               ●  1/1          0 Running  10.244.0.4   solo-control-plane   │
-│ kube-system         coredns-5d78c9869d-64lm6                               ●  1/1          0 Running  10.244.0.3   solo-control-plane   │
-│ kube-system         etcd-solo-control-plane                                ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
-│ kube-system         kindnet-6cng4                                          ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
-│ kube-system         kube-apiserver-solo-control-plane                      ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
-│ kube-system         kube-controller-manager-solo-control-plane             ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
-│ kube-system         kube-proxy-sg88w                                       ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
-│ kube-system         kube-scheduler-solo-control-plane                      ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
-│ local-path-storage  local-path-provisioner-6bc4bddd6b-7cv7c                ●  1/1          0 Running  10.244.0.2   solo-control-plane   │
-│ solo                envoy-proxy-node0-84947f844f-jn95h                     ●  1/1          0 Running  10.244.0.8   solo-control-plane   │
-│ solo                envoy-proxy-node1-65f8879dcc-8jnn8                     ●  1/1          0 Running  10.244.0.7   solo-control-plane   │
-│ solo                envoy-proxy-node2-667f848689-5hnrv                     ●  1/1          0 Running  10.244.0.13  solo-control-plane   │
-│ solo                fullstack-deployment-grpc-69f9cc5666-kjvbn             ●  1/1          0 Running  10.244.0.9   solo-control-plane   │
-│ solo                fullstack-deployment-hedera-explorer-79f79b7df4-xk79b  ●  1/1          0 Running  10.244.0.20  solo-control-plane   │
-│ solo                fullstack-deployment-importer-6bb8547f5b-5drzc         ●  1/1          0 Running  10.244.0.11  solo-control-plane   │
-│ solo                fullstack-deployment-postgres-postgresql-0             ●  1/1          0 Running  10.244.0.22  solo-control-plane   │
-│ solo                fullstack-deployment-rest-584f5cb6bb-6vr55             ●  1/1          0 Running  10.244.0.18  solo-control-plane   │
-│ solo                fullstack-deployment-web3-69dcdfc4fb-7vxmg             ●  1/1          0 Running  10.244.0.21  solo-control-plane   │
-│ solo                haproxy-node0-96f8df6d-74xws                           ●  1/1          0 Running  10.244.0.12  solo-control-plane   │
-│ solo                haproxy-node1-845fb68f48-49w82                         ●  1/1          0 Running  10.244.0.19  solo-control-plane   │
-│ solo                haproxy-node2-867656ff6-fm8sk                          ●  1/1          0 Running  10.244.0.10  solo-control-plane   │
-│ solo                minio-pool-1-0                                         ●  2/2          0 Running  10.244.0.24  solo-control-plane   │
-│ solo                network-node0-0                                        ●  6/6          0 Running  10.244.0.14  solo-control-plane   │
-│ solo                network-node1-0                                        ●  6/6          0 Running  10.244.0.16  solo-control-plane   │
-│ solo                network-node2-0                                        ●  6/6          0 Running  10.244.0.15  solo-control-plane   │
-│
+┌───────────────────────────────────────────────────────────────────────────────────────────────── Pods(all)[27] ──────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ NAMESPACE↑                 NAME                                                          PF        READY        STATUS                 RESTARTS IP                   NODE                        AGE             │
+│ kube-system                coredns-5d78c9869d-5ds5h                                      ●         1/1          Running                       0 10.244.0.4           solo-control-plane          26m             │
+│ kube-system                coredns-5d78c9869d-m99rt                                      ●         1/1          Running                       0 10.244.0.3           solo-control-plane          26m             │
+│ kube-system                etcd-solo-control-plane                                       ●         1/1          Running                       0 172.18.0.2           solo-control-plane          26m             │
+│ kube-system                kindnet-bh2cv                                                 ●         1/1          Running                       0 172.18.0.2           solo-control-plane          26m             │
+│ kube-system                kube-apiserver-solo-control-plane                             ●         1/1          Running                       0 172.18.0.2           solo-control-plane          26m             │
+│ kube-system                kube-controller-manager-solo-control-plane                    ●         1/1          Running                       0 172.18.0.2           solo-control-plane          26m             │
+│ kube-system                kube-proxy-tj9cf                                              ●         1/1          Running                       0 172.18.0.2           solo-control-plane          26m             │
+│ kube-system                kube-scheduler-solo-control-plane                             ●         1/1          Running                       0 172.18.0.2           solo-control-plane          26m             │
+│ local-path-storage         local-path-provisioner-6bc4bddd6b-n4xbj                       ●         1/1          Running                       0 10.244.0.2           solo-control-plane          26m             │
+│ solo                       envoy-proxy-node0-84947f844f-bh6nw                            ●         1/1          Running                       0 10.244.0.14          solo-control-plane          6m4s            │
+│ solo                       envoy-proxy-node1-65f8879dcc-p6m2l                            ●         1/1          Running                       0 10.244.0.10          solo-control-plane          6m4s            │
+│ solo                       envoy-proxy-node2-667f848689-fwlmz                            ●         1/1          Running                       0 10.244.0.13          solo-control-plane          6m4s            │
+│ solo                       fullstack-deployment-grpc-69f9cc5666-z62r2                    ●         1/1          Running                       0 10.244.0.19          solo-control-plane          6m4s            │
+│ solo                       fullstack-deployment-hedera-explorer-79f79b7df4-6z284         ●         1/1          Running                       0 10.244.0.15          solo-control-plane          6m4s            │
+│ solo                       fullstack-deployment-importer-6bb8547f5b-g9m4x                ●         1/1          Running                       0 10.244.0.16          solo-control-plane          6m4s            │
+│ solo                       fullstack-deployment-postgres-postgresql-0                    ●         1/1          Running                       0 10.244.0.24          solo-control-plane          6m4s            │
+│ solo                       fullstack-deployment-rest-584f5cb6bb-4h6m5                    ●         1/1          Running                       0 10.244.0.17          solo-control-plane          6m4s            │
+│ solo                       fullstack-deployment-web3-69dcdfc4fb-89pkm                    ●         1/1          Running                       0 10.244.0.23          solo-control-plane          6m3s            │
+│ solo                       haproxy-node0-96f8df6d-zq9tw                                  ●         1/1          Running                       0 10.244.0.9           solo-control-plane          6m4s            │
+│ solo                       haproxy-node1-845fb68f48-rrlb5                                ●         1/1          Running                       0 10.244.0.12          solo-control-plane          6m4s            │
+│ solo                       haproxy-node2-867656ff6-7fwgv                                 ●         1/1          Running                       0 10.244.0.11          solo-control-plane          6m4s            │
+│ solo                       minio-pool-1-0                                                ●         2/2          Running                       0 10.244.0.26          solo-control-plane          5m58s           │
+│ solo                       network-node0-0                                               ●         6/6          Running                       0 10.244.0.18          solo-control-plane          6m4s            │
+│ solo                       network-node1-0                                               ●         6/6          Running                       0 10.244.0.21          solo-control-plane          6m4s            │
+│ solo                       network-node2-0                                               ●         6/6          Running                       0 10.244.0.20          solo-control-plane          6m4s            │
+│ solo-cluster               console-557956d575-wkx5v                                      ●         1/1          Running                       0 10.244.0.8           solo-control-plane          7m31s           │
+│ solo-cluster               minio-operator-7d575c5f84-jwrjn                               ●         1/1          Running                       0 10.244.0.7           solo-control-plane          7m31s           │
+│                                                                                                                                                                                                                  │
 ```
 
 ### Access Hedera Network services
@@ -319,41 +321,41 @@ Once the nodes are up, you may now expose various services (using `k9s` (shift-f
 * Hedera explorer: `fullstack-deployment-hedera-explorer`
 
 ```
-┌─────────────────────────────────────────────────────────── Services(all)[24] ───────────────────────────────────────────────────────────┐
-│ NAMESPACE↑   NAME                                               TYPE          CLUSTER-IP     EXTERNAL-IP PORTS                          │
-│ default      console                                            ClusterIP     10.96.79.124               http:9090►0 https:9443►0       │
-│ default      kubernetes                                         ClusterIP     10.96.0.1                  https:443►0                    │
-│ default      operator                                           ClusterIP     10.96.110.186              http:4221►0                    │
-│ default      sts                                                ClusterIP     10.96.124.200              https:4223►0                   │
-│ kube-system  kube-dns                                           ClusterIP     10.96.0.10                 dns:53►0╱UDP dns-tcp:53►0 metr │
-│ solo         envoy-proxy-node0-svc                              ClusterIP     10.96.57.87                hedera-grpc-web:8080►0 prometh │
-│ solo         envoy-proxy-node1-svc                              ClusterIP     10.96.218.190              hedera-grpc-web:8080►0 prometh │
-│ solo         envoy-proxy-node2-svc                              ClusterIP     10.96.37.121               hedera-grpc-web:8080►0 prometh │
-│ solo         fullstack-deployment-grpc                          ClusterIP     10.96.194.119              grpc:5600►0 http:80►0          │
-│ solo         fullstack-deployment-hedera-explorer               ClusterIP     10.96.101.44               http:80►0                      │
-│ solo         fullstack-deployment-postgres-pgpool               ClusterIP     10.96.87.117               postgresql:5432►0              │
-│ solo         fullstack-deployment-postgres-postgresql           ClusterIP     10.96.45.88                postgresql:5432►0              │
-│ solo         fullstack-deployment-postgres-postgresql-headless  ClusterIP                                postgresql:5432►0              │
-│ solo         fullstack-deployment-rest                          ClusterIP     10.96.209.246              http:80►0                      │
-│ solo         fullstack-deployment-web3                          ClusterIP     10.96.218.212              http:80►0                      │
-│ solo         haproxy-node0-svc                                  LoadBalancer  10.96.231.160  <pending>   non-tls-grpc-client-port:50211 │
-│ solo         haproxy-node1-svc                                  LoadBalancer  10.96.24.61    <pending>   non-tls-grpc-client-port:50211 │
-│ solo         haproxy-node2-svc                                  LoadBalancer  10.96.186.144  <pending>   non-tls-grpc-client-port:50211 │
-│ solo         minio                                              ClusterIP     10.96.112.217              http-minio:80►0                │
-│ solo         minio-console                                      ClusterIP     10.96.245.34               http-console:9090►0            │
-│ solo         minio-hl                                           ClusterIP                                http-minio:9000►0              │
-│ solo         network-node0-svc                                  ClusterIP     10.96.111.149              gossip:50111►0 grpc-non-tls:50 │
-│ solo         network-node1-svc                                  ClusterIP     10.96.26.218               gossip:50111►0 grpc-non-tls:50 │
-│ solo         network-node2-svc                                  ClusterIP     10.96.114.167              gossip:50111►0 grpc-non-tls:50 │
- 
+┌─────────────────────────────────────────────────────────────────────────────────────────────── Services(all)[24] ────────────────────────────────────────────────────────────────────────────────────────────────┐
+│ NAMESPACE↑    NAME                                               TYPE          CLUSTER-IP     EXTERNAL-IP  PORTS                                                                                        AGE      │
+│ default       kubernetes                                         ClusterIP     10.96.0.1                   https:443►0                                                                                  27m      │
+│ kube-system   kube-dns                                           ClusterIP     10.96.0.10                  dns:53►0╱UDP dns-tcp:53►0 metrics:9153►0                                                     27m      │
+│ solo          envoy-proxy-node0-svc                              ClusterIP     10.96.190.57                hedera-grpc-web:8080►0 prometheus:9090►0                                                     7m1s     │
+│ solo          envoy-proxy-node1-svc                              ClusterIP     10.96.200.55                hedera-grpc-web:8080►0 prometheus:9090►0                                                     7m1s     │
+│ solo          envoy-proxy-node2-svc                              ClusterIP     10.96.127.86                hedera-grpc-web:8080►0 prometheus:9090►0                                                     7m1s     │
+│ solo          fullstack-deployment-grpc                          ClusterIP     10.96.130.194               grpc:5600►0 http:80►0                                                                        7m1s     │
+│ solo          fullstack-deployment-hedera-explorer               ClusterIP     10.96.239.23                http:80►0                                                                                    7m1s     │
+│ solo          fullstack-deployment-postgres-pgpool               ClusterIP     10.96.113.9                 postgresql:5432►0                                                                            7m1s     │
+│ solo          fullstack-deployment-postgres-postgresql           ClusterIP     10.96.149.174               postgresql:5432►0                                                                            7m1s     │
+│ solo          fullstack-deployment-postgres-postgresql-headless  ClusterIP                                 postgresql:5432►0                                                                            7m1s     │
+│ solo          fullstack-deployment-rest                          ClusterIP     10.96.212.206               http:80►0                                                                                    7m1s     │
+│ solo          fullstack-deployment-web3                          ClusterIP     10.96.9.179                 http:80►0                                                                                    7m1s     │
+│ solo          haproxy-node0-svc                                  LoadBalancer  10.96.181.106  <pending>    non-tls-grpc-client-port:50211►31438 tls-grpc-client-port:50212►30630 prometheus:9090►30474  7m1s     │
+│ solo          haproxy-node1-svc                                  LoadBalancer  10.96.26.200   <pending>    non-tls-grpc-client-port:50211►30989 tls-grpc-client-port:50212►30683 prometheus:9090►30243  7m1s     │
+│ solo          haproxy-node2-svc                                  LoadBalancer  10.96.46.132   <pending>    non-tls-grpc-client-port:50211►30306 tls-grpc-client-port:50212►31995 prometheus:9090►32545  7m1s     │
+│ solo          minio                                              ClusterIP     10.96.57.196                http-minio:80►0                                                                              6m56s    │
+│ solo          minio-console                                      ClusterIP     10.96.90.42                 http-console:9090►0                                                                          6m56s    │
+│ solo          minio-hl                                           ClusterIP                                 http-minio:9000►0                                                                            6m56s    │
+│ solo          network-node0-svc                                  ClusterIP     10.96.162.219               gossip:50111►0 grpc-non-tls:50211►0 grpc-tls:50212►0 prometheus:9090►0                       7m1s     │
+│ solo          network-node1-svc                                  ClusterIP     10.96.144.87                gossip:50111►0 grpc-non-tls:50211►0 grpc-tls:50212►0 prometheus:9090►0                       7m1s     │
+│ solo          network-node2-svc                                  ClusterIP     10.96.35.210                gossip:50111►0 grpc-non-tls:50211►0 grpc-tls:50212►0 prometheus:9090►0                       7m1s     │
+│ solo-cluster  console                                            ClusterIP     10.96.184.207               http:9090►0 https:9443►0                                                                     8m28s    │
+│ solo-cluster  operator                                           ClusterIP     10.96.250.178               http:4221►0                                                                                  8m28s    │
+│ solo-cluster  sts                                                ClusterIP     10.96.19.237                https:4223►0                                                                                 8m28s    │
+│                                                                                                                                                                                                                  │
 ```
 
 ## Example - 2: Deploy a private Hedera network (version `0.47.0-alpha.0`)
 
-* Initialize `solo` with tag `v0.47.0-alpha.0` and list of node names `node0,node1,node2`:
+* Initialize `solo` with tag `v0.47.0-alpha.0` and list of node names `n0,n1,n2`:
 
 ```
-$ solo init -t v0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
+$ solo init -t v0.47.0-alpha.0 -i n0,n1,n2 -n "${SOLO_NAMESPACE}" -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" 
 
 # output is similar as example-1 
 ```
@@ -361,7 +363,7 @@ $ solo init -t v0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}"
 * Generate `pem` node keys for default node IDs: node0,node1,node2
 
 ```
-$ solo node keys --gossip-keys --tls-keys --key-format pem -i node0,node1,node2
+$ solo node keys --gossip-keys --tls-keys --key-format pem
 
 ******************************* Solo *********************************************
 Version                 : 0.19.1
@@ -374,15 +376,12 @@ Kubernetes Namespace    : solo
 ✔ Generate gRPC TLS keys
 
 $ ls ~/.solo/cache/keys  
-a-private-node0.pem a-public-node0.pem  hedera-node0.crt    hedera-node1.key    private-node0.pfx   public.pfx          s-private-node2.pem s-public-node2.pem
-a-private-node1.pem a-public-node1.pem  hedera-node0.key    hedera-node2.crt    private-node1.pfx   s-private-node0.pem s-public-node0.pem
-a-private-node2.pem a-public-node2.pem  hedera-node1.crt    hedera-node2.key    private-node2.pfx   s-private-node1.pem s-public-node1.pem
-
-
+a-private-n0.pem a-private-n2.pem a-public-n1.pem  hedera-n0.crt    hedera-n1.crt    hedera-n2.crt    s-private-n0.pem s-private-n2.pem s-public-n1.pem
+a-private-n1.pem a-public-n0.pem  a-public-n2.pem  hedera-n0.key    hedera-n1.key    hedera-n2.key    s-private-n1.pem s-public-n0.pem  s-public-n2.pem
 
 ```
 
-* Setup cluster with shared components (by default it is installed in the `default` namespace)
+* Setup cluster with shared components
 
 ```
 $ solo cluster setup

--- a/solo/README.md
+++ b/solo/README.md
@@ -395,7 +395,7 @@ In a separate terminal, you may run `k9s` to view the pod status.
 * Deploy helm chart with Hedera network components
 
 ```
-solo network deploy
+$ solo network deploy
 
 # output is similar to example-1 
 ```

--- a/solo/README.md
+++ b/solo/README.md
@@ -34,7 +34,7 @@ $ nvm use lts/hydrogen
   Check and select appropriate kubernetes context using `kubectx` command as below:
 
 ```
-kubectx <context-name>
+$ kubectx <context-name>
 ```
 
 * For a local cluster, you may use [kind](https://kind.sigs.k8s.io/) and [kubectl](https://kubernetes.io/docs/tasks/tools/) to create a cluster and namespace as below.

--- a/solo/README.md
+++ b/solo/README.md
@@ -405,7 +405,7 @@ $ solo network deploy
     pods started.
 
 ```
-solo node setup
+$ solo node setup
 
 # output is similar to example-1 
 ```

--- a/solo/README.md
+++ b/solo/README.md
@@ -4,13 +4,19 @@ An opinionated CLI tool to deploy and manage private Hedera Networks.
 
 ## Requirements
 
-* Node(^18.19.0)
+* Node(^18.19.0) (*lts/hydrogen*)
 * Helm(^3.14.0)
 * Kubectl(^1.28.2)
 
 ## Setup
 
-* Install [Node](https://nodejs.org/en/download). You may also use [nvm](https://github.com/nvm-sh/nvm) to manage different Node versions locally
+* Install [Node](https://nodejs.org/en/download). You may also use [nvm](https://github.com/nvm-sh/nvm) to manage different Node versions locally:
+
+```
+nvm install lts/hydrogen
+nvm use lts/hydrogen 
+```
+
 * Install [kubectl](https://kubernetes.io/docs/tasks/tools/)
 * Install [helm](https://helm.sh/docs/intro/install/)
 * Useful tools (Optional)
@@ -24,22 +30,63 @@ An opinionated CLI tool to deploy and manage private Hedera Networks.
 
 ## Setup Kubernetes cluster
 
-* If you don't already have a cluster, you may use [kind](https://kind.sigs.k8s.io/) and
-  [kubectl](https://kubernetes.io/docs/tasks/tools/) to create a cluster and namespace as below:
+* You may use remote kubernetes cluster. In this case, ensure kubernetes context is set up correctly.
+  Check and select appropriate kubernetes context using `kubectx` command as below:
+
+```
+kubectx <context-name>
+```
+
+* For a local cluster, you may use [kind](https://kind.sigs.k8s.io/) and [kubectl](https://kubernetes.io/docs/tasks/tools/) to create a cluster and namespace as below.
+  * In this case, ensure your Docker has enough resources (e.g. Memory >=8Gb, CPU: >=4).
 
 ```
 export SOLO_CLUSTER_NAME=solo
 export SOLO_NAMESPACE=solo
 kind create cluster -n "${SOLO_CLUSTER_NAME}" 
 kubectl create ns "${SOLO_NAMESPACE}" 
+
+Creating cluster "solo" ...
+ ✓ Ensuring node image (kindest/node:v1.27.3) 🖼
+ ✓ Preparing nodes 📦
+ ✓ Writing configuration 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Installing CNI 🔌
+ ✓ Installing StorageClass 💾
+Set kubectl context to "kind-solo"
+You can now use your cluster with:
+
+kubectl cluster-info --context kind-solo
+
+Have a nice day! 👋
+namespace/solo created
+```
+
+You may now view pods in your cluster using `k8s` as below:
+
+```
+ Context: kind-solo                                <0> all       <a>      Attac… ____  __.________
+ Cluster: kind-solo                                <1> default   <ctrl-d> Delete|    |/ _/   __   \______
+ User:    kind-solo                                              <d>      Descri|      < \____    /  ___/
+ K9s Rev: v0.27.4 ⚡️v0.31.7                                      <e>      Edit  |    |  \   /    /\___ \
+ K8s Rev: v1.27.3                                                <?>      Help  |____|__ \ /____//____  >
+ CPU:     n/a                                                    <ctrl-k> Kill          \/            \/
+ MEM:     n/a
+┌───────────────────────────────────────────── Pods(all)[9] ─────────────────────────────────────────────┐
+│ NAMESPACE↑          NAME                                        PF READY RESTARTS STATUS   IP          │
+│ kube-system         coredns-5d78c9869d-8x4zm                    ●  1/1          0 Running  10.244.0.4  │
+│ kube-system         coredns-5d78c9869d-64lm6                    ●  1/1          0 Running  10.244.0.3  │
+│ kube-system         etcd-solo-control-plane                     ●  1/1          0 Running  172.18.0.2  │
+│ kube-system         kindnet-6cng4                               ●  1/1          0 Running  172.18.0.2  │
+│ kube-system         kube-apiserver-solo-control-plane           ●  1/1          0 Running  172.18.0.2  │
+│ kube-system         kube-controller-manager-solo-control-plane  ●  1/1          0 Running  172.18.0.2  │
+│ kube-system         kube-proxy-sg88w                            ●  1/1          0 Running  172.18.0.2  │
+│ kube-system         kube-scheduler-solo-control-plane           ●  1/1          0 Running  172.18.0.2  │
+│ local-path-storage  local-path-provisioner-6bc4bddd6b-7cv7c     ●  1/1          0 Running  10.244.0.2  │
+│
 ```
 
 ## Generate Node Keys
-
-### Standard keys (.pem file)
-
-These keys are supported by Hedera platform >=`0.47.0-alpha.0`.
-You may run `solo node keys --gossip-keys --tls-keys --key-format pem -i node0,node1,node2` command to generate the required node keys.
 
 ### Legacy keys (.pfx file)
 
@@ -59,68 +106,288 @@ chmod +x gen-legacy-keys.sh
 ./gen-legacy-keys.sh alice,bob,carol
 ```
 
+### Standard keys (.pem file)
+
+These keys are supported by Hedera platform >=`0.47.0-alpha.0`.
+You may run `solo node keys --gossip-keys --tls-keys --key-format pem -i node0,node1,node2` command to generate the required node keys.
+
 # Examples
 
-## Deploy a private Hedera network (version `0.42.5`)
+## Example - 1: Deploy a private Hedera network (version `0.42.5`)
 
-* Initialize `solo`
-
-```
-solo init -t 0.42.5 # cache args for subsequent commands
-```
-
-* Generate `pfx` node keys for default node IDs: node0,node1,node2 (You will need `curl`, `keytool` and `openssl`)
+* Initialize `solo` with tag `v0.42.5` and list of node names `node0,node1,node2`:
 
 ```
-/bin/bash -c "$(curl -fsSL  https://raw.githubusercontent.com/hashgraph/full-stack-testing/main/solo/test/scripts/gen-legacy-keys.sh)"
+$ solo init -t 0.42.5 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
+
+******************************* Solo *********************************************
+Version                 : 0.19.1
+Kubernetes Context      : kind-solo
+Kubernetes Cluster      : kind-solo
+Kubernetes Namespace    : solo
+**********************************************************************************
+✔ Setup home directory and cache
+✔ Setup config manager
+✔ Check dependencies
+  ✔ Check dependency: helm
+✔ Setup chart manager [1s]
 ```
 
-* Setup cluster with shared components in the `default` namespace
+* Generate `pfx` node keys (You will need `curl`, `keytool` and `openssl`)
 
 ```
-solo cluster setup -n default 
+curl https://raw.githubusercontent.com/hashgraph/full-stack-testing/main/solo/test/scripts/gen-legacy-keys.sh -o gen-legacy-keys.sh
+chmod +x gen-legacy-keys.sh
+./gen-legacy-keys.sh node0,node1,node2
+
+# view the list of generated keys in the cache folder
+$ ls ~/.solo/cache/keys                                                                    
+hedera-node0.crt  hedera-node1.crt  hedera-node2.crt  private-node0.pfx private-node2.pfx
+hedera-node0.key  hedera-node1.key  hedera-node2.key  private-node1.pfx public.pfx
+
+```
+
+* Setup cluster with shared components (by default it is installed in the `default` namespace)
+
+```
+$ solo cluster setup
+
+******************************* Solo *********************************************
+Version                 : 0.19.1
+Kubernetes Context      : kind-solo
+Kubernetes Cluster      : kind-solo
+Kubernetes Namespace    : solo
+**********************************************************************************
+✔ Initialize
+✔ Prepare chart values
+✔ Install 'fullstack-cluster-setup' chart [1s]
+
 ```
 
 In a separate terminal, you may run `k9s` to view the pod status.
 
 * Deploy helm chart with Hedera network components
+  * It may take a while (5~15 minutes depending on your internet speed) to download various docker images and get the pods started.
+  * If it fails, ensure you have enough resources allocated for Docker and restart.
 
 ```
-solo network deploy -n "${SOLO_NAMESPACE}" 
+$ solo network deploy
+
+******************************* Solo *********************************************
+Version                 : 0.19.1
+Kubernetes Context      : kind-solo
+Kubernetes Cluster      : kind-solo
+Kubernetes Namespace    : solo
+**********************************************************************************
+(node:76336) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+✔ Initialize
+✔ Install chart 'fullstack-deployment' [3s]
+✔ Waiting for network pods to be ready [8m54s]
+  ✔ Node: node0 (Pod: network-node0-0) [8m54s]
+  ✔ Node: node1 (Pod: network-node1-0)
+  ✔ Node: node2 (Pod: network-node2-0)
+
 ```
 
-* Setup node with Hedera platform. It may take a while (~10 minutes depending on your internet speed) to download
-  various docker images and get the pods started.
+* Setup node with Hedera platform software.
+  * It may take a while as it download the hedera platform code from <https://builds.hedera.com/>
 
 ```
-solo node setup
+$ solo node setup
+
+******************************* Solo *********************************************
+Version                 : 0.19.1
+Kubernetes Context      : kind-solo
+Kubernetes Cluster      : kind-solo
+Kubernetes Namespace    : solo
+**********************************************************************************
+(node:78205) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+(Use `node --trace-deprecation ...` to show where the warning was created)
+✔ Initialize
+✔ Identify network pods
+  ✔ Check network pod: node0
+  ✔ Check network pod: node1
+  ✔ Check network pod: node2
+✔ Fetch platform software
+↓ Generate Gossip keys
+↓ Generate gRPC TLS keys
+✔ Prepare staging directory
+  ✔ Copy default files and templates
+  ✔ Copy Gossip keys to staging
+  ✔ Copy gRPC TLS keys to staging
+  ✔ Prepare config.txt for the network
+✔ Upload platform software into network nodes [5s]
+  ✔ Node: node0 [1s]
+  ✔ Node: node1 [1s]
+  ✔ Node: node2 [1s]
+✔ Setup network nodes [1s]
+  ✔ Node: node0 [1s]
+    ✔ Copy Gossip keys [0.3s]
+    ✔ Copy TLS keys [0.3s]
+    ✔ Copy configuration files [0.8s]
+    ✔ Set file permissions
+  ✔ Node: node1 [1s]
+    ✔ Copy Gossip keys [0.2s]
+    ✔ Copy TLS keys [0.3s]
+    ✔ Copy configuration files [0.8s]
+    ✔ Set file permissions [0.1s]
+  ✔ Node: node2 [1s]
+    ✔ Copy Gossip keys [0.2s]
+    ✔ Copy TLS keys [0.3s]
+    ✔ Copy configuration files [0.8s]
+    ✔ Set file permissions [0.1s]
 
 ```
 
 * Start the nodes
 
 ```
-solo node start
+$ solo node start
+
+******************************* Solo *********************************************
+Version                 : 0.19.1
+Kubernetes Context      : kind-solo
+Kubernetes Cluster      : kind-solo
+Kubernetes Namespace    : solo
+**********************************************************************************
+✔ Initialize
+✔ Identify network pods
+  ✔ Check network pod: node0
+  ✔ Check network pod: node1
+  ✔ Check network pod: node2
+✔ Starting nodes
+  ✔ Start node: node0
+  ✔ Start node: node1
+  ✔ Start node: node2
+✔ Check nodes are ACTIVE [23s]
+  ✔ Check node: node0 [23s]
+  ✔ Check node: node1 [0.1s]
+  ✔ Check node: node2 [0.1s]
+
 ```
 
-## Deploy a private Hedera network (version `0.47.0-alpha.0`)
-
-* Initialize `solo`
+You may view the list of pods using `k9s` as below:
 
 ```
-solo init -t 0.47.0-alpha.0 # cache args for subsequent commands
+ Context: kind-solo                                <0> all       <a>      Attach     <l>       Logs               ____  __.________
+ Cluster: kind-solo                                <1> default   <ctrl-d> Delete     <p>       Logs Previous     |    |/ _/   __   \______
+ User:    kind-solo                                              <d>      Describe   <shift-f> Port-Forward      |      < \____    /  ___/
+ K9s Rev: v0.27.4 ⚡️v0.31.7                                      <e>      Edit       <s>       Shell             |    |  \   /    /\___ \
+ K8s Rev: v1.27.3                                                <?>      Help       <n>       Show Node         |____|__ \ /____//____  >
+ CPU:     n/a                                                    <ctrl-k> Kill       <f>       Show PortForward          \/            \/
+ MEM:     n/a
+┌───────────────────────────────────────────────────────────── Pods(all)[27] ─────────────────────────────────────────────────────────────┐
+│ NAMESPACE↑          NAME                                                   PF READY RESTARTS STATUS   IP           NODE                 │
+│ default             console-557956d575-4tph9                               ●  1/1          0 Running  10.244.0.6   solo-control-plane   │
+│ default             minio-operator-7d575c5f84-mkk8t                        ●  1/1          0 Running  10.244.0.5   solo-control-plane   │
+│ kube-system         coredns-5d78c9869d-8x4zm                               ●  1/1          0 Running  10.244.0.4   solo-control-plane   │
+│ kube-system         coredns-5d78c9869d-64lm6                               ●  1/1          0 Running  10.244.0.3   solo-control-plane   │
+│ kube-system         etcd-solo-control-plane                                ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
+│ kube-system         kindnet-6cng4                                          ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
+│ kube-system         kube-apiserver-solo-control-plane                      ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
+│ kube-system         kube-controller-manager-solo-control-plane             ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
+│ kube-system         kube-proxy-sg88w                                       ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
+│ kube-system         kube-scheduler-solo-control-plane                      ●  1/1          0 Running  172.18.0.2   solo-control-plane   │
+│ local-path-storage  local-path-provisioner-6bc4bddd6b-7cv7c                ●  1/1          0 Running  10.244.0.2   solo-control-plane   │
+│ solo                envoy-proxy-node0-84947f844f-jn95h                     ●  1/1          0 Running  10.244.0.8   solo-control-plane   │
+│ solo                envoy-proxy-node1-65f8879dcc-8jnn8                     ●  1/1          0 Running  10.244.0.7   solo-control-plane   │
+│ solo                envoy-proxy-node2-667f848689-5hnrv                     ●  1/1          0 Running  10.244.0.13  solo-control-plane   │
+│ solo                fullstack-deployment-grpc-69f9cc5666-kjvbn             ●  1/1          0 Running  10.244.0.9   solo-control-plane   │
+│ solo                fullstack-deployment-hedera-explorer-79f79b7df4-xk79b  ●  1/1          0 Running  10.244.0.20  solo-control-plane   │
+│ solo                fullstack-deployment-importer-6bb8547f5b-5drzc         ●  1/1          0 Running  10.244.0.11  solo-control-plane   │
+│ solo                fullstack-deployment-postgres-postgresql-0             ●  1/1          0 Running  10.244.0.22  solo-control-plane   │
+│ solo                fullstack-deployment-rest-584f5cb6bb-6vr55             ●  1/1          0 Running  10.244.0.18  solo-control-plane   │
+│ solo                fullstack-deployment-web3-69dcdfc4fb-7vxmg             ●  1/1          0 Running  10.244.0.21  solo-control-plane   │
+│ solo                haproxy-node0-96f8df6d-74xws                           ●  1/1          0 Running  10.244.0.12  solo-control-plane   │
+│ solo                haproxy-node1-845fb68f48-49w82                         ●  1/1          0 Running  10.244.0.19  solo-control-plane   │
+│ solo                haproxy-node2-867656ff6-fm8sk                          ●  1/1          0 Running  10.244.0.10  solo-control-plane   │
+│ solo                minio-pool-1-0                                         ●  2/2          0 Running  10.244.0.24  solo-control-plane   │
+│ solo                network-node0-0                                        ●  6/6          0 Running  10.244.0.14  solo-control-plane   │
+│ solo                network-node1-0                                        ●  6/6          0 Running  10.244.0.16  solo-control-plane   │
+│ solo                network-node2-0                                        ●  6/6          0 Running  10.244.0.15  solo-control-plane   │
+│
+```
+
+### Access Hedera Network services
+
+Once the nodes are up, you may now expose various services (using `k9s` (shift-f) or `kubectl port-forward`) and access. Below are most used services that you may expose.
+
+* Node services: Prefix `network-<node ID>-svc`
+* HAProxy: `haproxy-<node ID>-svc`
+* EnvoyProxy: `envoy-proxy-<node ID>-svc`
+* Hedera explorer: `fullstack-deployment-hedera-explorer`
+
+```
+┌─────────────────────────────────────────────────────────── Services(all)[24] ───────────────────────────────────────────────────────────┐
+│ NAMESPACE↑   NAME                                               TYPE          CLUSTER-IP     EXTERNAL-IP PORTS                          │
+│ default      console                                            ClusterIP     10.96.79.124               http:9090►0 https:9443►0       │
+│ default      kubernetes                                         ClusterIP     10.96.0.1                  https:443►0                    │
+│ default      operator                                           ClusterIP     10.96.110.186              http:4221►0                    │
+│ default      sts                                                ClusterIP     10.96.124.200              https:4223►0                   │
+│ kube-system  kube-dns                                           ClusterIP     10.96.0.10                 dns:53►0╱UDP dns-tcp:53►0 metr │
+│ solo         envoy-proxy-node0-svc                              ClusterIP     10.96.57.87                hedera-grpc-web:8080►0 prometh │
+│ solo         envoy-proxy-node1-svc                              ClusterIP     10.96.218.190              hedera-grpc-web:8080►0 prometh │
+│ solo         envoy-proxy-node2-svc                              ClusterIP     10.96.37.121               hedera-grpc-web:8080►0 prometh │
+│ solo         fullstack-deployment-grpc                          ClusterIP     10.96.194.119              grpc:5600►0 http:80►0          │
+│ solo         fullstack-deployment-hedera-explorer               ClusterIP     10.96.101.44               http:80►0                      │
+│ solo         fullstack-deployment-postgres-pgpool               ClusterIP     10.96.87.117               postgresql:5432►0              │
+│ solo         fullstack-deployment-postgres-postgresql           ClusterIP     10.96.45.88                postgresql:5432►0              │
+│ solo         fullstack-deployment-postgres-postgresql-headless  ClusterIP                                postgresql:5432►0              │
+│ solo         fullstack-deployment-rest                          ClusterIP     10.96.209.246              http:80►0                      │
+│ solo         fullstack-deployment-web3                          ClusterIP     10.96.218.212              http:80►0                      │
+│ solo         haproxy-node0-svc                                  LoadBalancer  10.96.231.160  <pending>   non-tls-grpc-client-port:50211 │
+│ solo         haproxy-node1-svc                                  LoadBalancer  10.96.24.61    <pending>   non-tls-grpc-client-port:50211 │
+│ solo         haproxy-node2-svc                                  LoadBalancer  10.96.186.144  <pending>   non-tls-grpc-client-port:50211 │
+│ solo         minio                                              ClusterIP     10.96.112.217              http-minio:80►0                │
+│ solo         minio-console                                      ClusterIP     10.96.245.34               http-console:9090►0            │
+│ solo         minio-hl                                           ClusterIP                                http-minio:9000►0              │
+│ solo         network-node0-svc                                  ClusterIP     10.96.111.149              gossip:50111►0 grpc-non-tls:50 │
+│ solo         network-node1-svc                                  ClusterIP     10.96.26.218               gossip:50111►0 grpc-non-tls:50 │
+│ solo         network-node2-svc                                  ClusterIP     10.96.114.167              gossip:50111►0 grpc-non-tls:50 │
+ 
+```
+
+## Example - 2: Deploy a private Hedera network (version `0.47.0-alpha.0`)
+
+* Initialize `solo` with tag `v0.42.5` and list of node names `node0,node1,node2`:
+
+```
+$ solo init -t 0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
+
+# output is similar as example-1 
 ```
 
 * Generate `pem` node keys for default node IDs: node0,node1,node2
 
 ```
 solo node keys --gossip-keys --tls-keys --key-format pem -i node0,node1,node2
+
+******************************* Solo *********************************************
+Version                 : 0.19.1
+Kubernetes Context      : kind-solo
+Kubernetes Cluster      : kind-solo
+Kubernetes Namespace    : solo
+**********************************************************************************
+✔ Initialize
+✔ Generate gossip keys
+✔ Generate gRPC TLS keys
+
+$ ls ~/.solo/cache/keys  
+a-private-node0.pem a-public-node0.pem  hedera-node0.crt    hedera-node1.key    private-node0.pfx   public.pfx          s-private-node2.pem s-public-node2.pem
+a-private-node1.pem a-public-node1.pem  hedera-node0.key    hedera-node2.crt    private-node1.pfx   s-private-node0.pem s-public-node0.pem
+a-private-node2.pem a-public-node2.pem  hedera-node1.crt    hedera-node2.key    private-node2.pfx   s-private-node1.pem s-public-node1.pem
+
+
+
 ```
 
-* Setup cluster with shared components in the `default` namespace
+* Setup cluster with shared components (by default it is installed in the `default` namespace)
 
 ```
-solo cluster setup -n default 
+solo cluster setup
+
+# output is similar to example-1 
 ```
 
 In a separate terminal, you may run `k9s` to view the pod status.
@@ -128,19 +395,25 @@ In a separate terminal, you may run `k9s` to view the pod status.
 * Deploy helm chart with Hedera network components
 
 ```
-solo network deploy -n "${SOLO_NAMESPACE}" 
+solo network deploy
+
+# output is similar to example-1 
 ```
 
-* Setup node with Hedera platform. It may take a while (~10 minutes depending on your internet speed) to download
-  various docker images and get the pods started.
+* Setup node with Hedera platform.
+  * It may take a while (~10 minutes depending on your internet speed) to download various docker images and get the
+    pods started.
 
 ```
 solo node setup
 
+# output is similar to example-1 
 ```
 
 * Start the nodes
 
 ```
 solo node start
+
+# output is similar to example-1 
 ```

--- a/solo/README.md
+++ b/solo/README.md
@@ -413,7 +413,7 @@ solo node setup
 * Start the nodes
 
 ```
-solo node start
+$ solo node start
 
 # output is similar to example-1 
 ```

--- a/solo/README.md
+++ b/solo/README.md
@@ -385,7 +385,7 @@ a-private-node2.pem a-public-node2.pem  hedera-node1.crt    hedera-node2.key    
 * Setup cluster with shared components (by default it is installed in the `default` namespace)
 
 ```
-solo cluster setup
+$ solo cluster setup
 
 # output is similar to example-1 
 ```

--- a/solo/README.md
+++ b/solo/README.md
@@ -118,7 +118,7 @@ You may run `solo node keys --gossip-keys --tls-keys --key-format pem -i node0,n
 * Initialize `solo` with tag `v0.42.5` and list of node names `node0,node1,node2`:
 
 ```
-$ solo init -t 0.42.5 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
+$ solo init -t v0.42.5 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
 
 ******************************* Solo *********************************************
 Version                 : 0.19.1
@@ -353,7 +353,7 @@ Once the nodes are up, you may now expose various services (using `k9s` (shift-f
 * Initialize `solo` with tag `v0.42.5` and list of node names `node0,node1,node2`:
 
 ```
-$ solo init -t 0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
+$ solo init -t v0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 
 
 # output is similar as example-1 
 ```

--- a/solo/README.md
+++ b/solo/README.md
@@ -350,7 +350,7 @@ Once the nodes are up, you may now expose various services (using `k9s` (shift-f
 
 ## Example - 2: Deploy a private Hedera network (version `0.47.0-alpha.0`)
 
-* Initialize `solo` with tag `v0.42.5` and list of node names `node0,node1,node2`:
+* Initialize `solo` with tag `v0.47.0-alpha.0` and list of node names `node0,node1,node2`:
 
 ```
 $ solo init -t v0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}" 

--- a/solo/README.md
+++ b/solo/README.md
@@ -62,7 +62,7 @@ Have a nice day! 👋
 namespace/solo created
 ```
 
-You may now view pods in your cluster using `k9s` as below:
+You may now view pods in your cluster using `k9s -A` as below:
 
 ```
  Context: kind-solo                                <0> all       <a>      Attac… ____  __.________

--- a/solo/README.md
+++ b/solo/README.md
@@ -41,10 +41,10 @@ $ kubectx <context-name>
   * In this case, ensure your Docker has enough resources (e.g. Memory >=8Gb, CPU: >=4).
 
 ```
-export SOLO_CLUSTER_NAME=solo
-export SOLO_NAMESPACE=solo
-kind create cluster -n "${SOLO_CLUSTER_NAME}" 
-kubectl create ns "${SOLO_NAMESPACE}" 
+$ export SOLO_CLUSTER_NAME=solo
+$ export SOLO_NAMESPACE=solo
+$ kind create cluster -n "${SOLO_CLUSTER_NAME}" 
+$ kubectl create ns "${SOLO_NAMESPACE}" 
 
 Creating cluster "solo" ...
  ✓ Ensuring node image (kindest/node:v1.27.3) 🖼

--- a/solo/README.md
+++ b/solo/README.md
@@ -136,9 +136,9 @@ Kubernetes Namespace    : solo
 * Generate `pfx` node keys (You will need `curl`, `keytool` and `openssl`)
 
 ```
-curl https://raw.githubusercontent.com/hashgraph/full-stack-testing/main/solo/test/scripts/gen-legacy-keys.sh -o gen-legacy-keys.sh
-chmod +x gen-legacy-keys.sh
-./gen-legacy-keys.sh node0,node1,node2
+$ curl https://raw.githubusercontent.com/hashgraph/full-stack-testing/main/solo/test/scripts/gen-legacy-keys.sh -o gen-legacy-keys.sh
+$ chmod +x gen-legacy-keys.sh
+$ ./gen-legacy-keys.sh node0,node1,node2
 
 # view the list of generated keys in the cache folder
 $ ls ~/.solo/cache/keys                                                                    

--- a/solo/README.md
+++ b/solo/README.md
@@ -361,7 +361,7 @@ $ solo init -t v0.47.0-alpha.0 -i node0,node1,node2 -n "${SOLO_NAMESPACE}"
 * Generate `pem` node keys for default node IDs: node0,node1,node2
 
 ```
-solo node keys --gossip-keys --tls-keys --key-format pem -i node0,node1,node2
+$ solo node keys --gossip-keys --tls-keys --key-format pem -i node0,node1,node2
 
 ******************************* Solo *********************************************
 Version                 : 0.19.1

--- a/solo/README.md
+++ b/solo/README.md
@@ -13,8 +13,8 @@ An opinionated CLI tool to deploy and manage private Hedera Networks.
 * Install [Node](https://nodejs.org/en/download). You may also use [nvm](https://github.com/nvm-sh/nvm) to manage different Node versions locally:
 
 ```
-nvm install lts/hydrogen
-nvm use lts/hydrogen 
+$ nvm install lts/hydrogen
+$ nvm use lts/hydrogen 
 ```
 
 * Install [kubectl](https://kubernetes.io/docs/tasks/tools/)

--- a/solo/README.md
+++ b/solo/README.md
@@ -62,7 +62,7 @@ Have a nice day! 👋
 namespace/solo created
 ```
 
-You may now view pods in your cluster using `k8s` as below:
+You may now view pods in your cluster using `k9s` as below:
 
 ```
  Context: kind-solo                                <0> all       <a>      Attac… ____  __.________

--- a/solo/src/commands/cluster.mjs
+++ b/solo/src/commands/cluster.mjs
@@ -56,6 +56,7 @@ export class ClusterCommand extends BaseCommand {
           self.configManager.load()
           const prevNamespace = self.configManager.getFlag(flags.namespace)
 
+          self.configManager.load(argv)
           await prompts.execute(task, self.configManager, [
             flags.chartDirectory,
             flags.fstChartVersion,

--- a/solo/src/commands/flags.mjs
+++ b/solo/src/commands/flags.mjs
@@ -180,7 +180,7 @@ export const nodeIDs = {
   name: 'node-ids',
   definition: {
     describe: 'Comma separated node IDs (empty means all nodes)',
-    default: 'node0,node1,node2',
+    default: '',
     alias: 'i',
     type: 'string'
   }
@@ -268,7 +268,8 @@ export const keyFormat = {
   name: 'key-format',
   definition: {
     describe: 'Public and Private key file format (pem or pfx)',
-    default: 'pfx'
+    default: 'pfx',
+    type: 'string'
   }
 }
 
@@ -311,7 +312,7 @@ export const hederaExplorerTlsHostName = {
 export const deletePvcs = {
   name: 'delete-pvcs',
   definition: {
-    describe: 'Delete the persistent volume claims, defaults to false',
+    describe: 'Delete the persistent volume claims',
     default: false,
     type: 'boolean'
   }

--- a/solo/src/commands/flags.mjs
+++ b/solo/src/commands/flags.mjs
@@ -10,32 +10,15 @@ import * as helpers from '../core/helpers.mjs'
  */
 export function setCommandFlags (y, ...commandFlags) {
   commandFlags.forEach(flag => {
-    setCommandFlag(y, flag, false)
-  })
-}
-
-export function setCommandFlag (y, flag, demand = false) {
-  if (demand) {
-    const def = JSON.parse(JSON.stringify(flag.definition))
-    delete (def.default)
-    def.demand = demand
-    y.option(flag.name, def)
-  } else {
     y.option(flag.name, flag.definition)
-  }
-}
-
-export function withDefaultValue (f, value) {
-  const clone = JSON.parse(JSON.stringify(f))
-  clone.definition.default = value
-  return clone
+  })
 }
 
 export const devMode = {
   name: 'dev',
   definition: {
     describe: 'Enable developer mode',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -45,8 +28,17 @@ export const clusterName = {
   name: 'cluster-name',
   definition: {
     describe: 'Cluster name',
-    default: '',
+    defaultValue: '',
     alias: 'c',
+    type: 'string'
+  }
+}
+
+export const clusterSetupNamespace = {
+  name: 'cluster-setup-namespace',
+  definition: {
+    describe: 'Cluster Setup Namespace',
+    alias: 's',
     type: 'string'
   }
 }
@@ -55,7 +47,6 @@ export const namespace = {
   name: 'namespace',
   definition: {
     describe: 'Namespace',
-    default: '',
     alias: 'n',
     type: 'string'
   }
@@ -65,7 +56,7 @@ export const kubeContext = {
   name: 'kube-context',
   definition: {
     describe: 'Kube context',
-    default: '',
+    defaultValue: '',
     type: 'string'
   }
 }
@@ -74,7 +65,7 @@ export const deployMirrorNode = {
   name: 'mirror-node',
   definition: {
     describe: 'Deploy mirror node',
-    default: true,
+    defaultValue: true,
     alias: 'm',
     type: 'boolean'
   }
@@ -84,7 +75,7 @@ export const deployHederaExplorer = {
   name: 'hedera-explorer',
   definition: {
     describe: 'Deploy hedera explorer',
-    default: true,
+    defaultValue: true,
     alias: 'x',
     type: 'boolean'
   }
@@ -94,7 +85,7 @@ export const valuesFile = {
   name: 'values-file',
   definition: {
     describe: 'Comma separated chart values files',
-    default: '',
+    defaultValue: '',
     alias: 'f',
     type: 'string'
   }
@@ -104,7 +95,7 @@ export const deployPrometheusStack = {
   name: 'prometheus-stack',
   definition: {
     describe: 'Deploy prometheus stack',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -113,7 +104,7 @@ export const enablePrometheusSvcMonitor = {
   name: 'enable-prometheus-svc-monitor',
   definition: {
     describe: 'Enable prometheus service monitor for the network nodes',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -122,7 +113,7 @@ export const deployMinio = {
   name: 'minio',
   definition: {
     describe: 'Deploy minio operator',
-    default: true,
+    defaultValue: true,
     type: 'boolean'
   }
 }
@@ -131,7 +122,7 @@ export const deployCertManager = {
   name: 'cert-manager',
   definition: {
     describe: 'Deploy cert manager, also deploys acme-cluster-issuer',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -144,7 +135,7 @@ export const deployCertManagerCrds = {
   name: 'cert-manager-crds',
   definition: {
     describe: 'Deploy cert manager CRDs',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -153,7 +144,7 @@ export const deployJsonRpcRelay = {
   name: 'json-rpc-relay',
   definition: {
     describe: 'Deploy JSON RPC Relay',
-    default: false,
+    defaultValue: false,
     alias: 'j',
     type: 'boolean'
   }
@@ -163,7 +154,6 @@ export const releaseTag = {
   name: 'release-tag',
   definition: {
     describe: 'Release tag to be used (e.g. v0.42.5)',
-    default: '',
     alias: 't',
     type: 'string'
   }
@@ -173,7 +163,7 @@ export const relayReleaseTag = {
   name: 'relay-release',
   definition: {
     describe: 'Relay release tag to be used (e.g. v0.39.1)',
-    default: '',
+    defaultValue: '',
     type: 'string'
   }
 }
@@ -182,7 +172,7 @@ export const cacheDir = {
   name: 'cache-dir',
   definition: {
     describe: 'Local cache directory',
-    default: core.constants.SOLO_CACHE_DIR,
+    defaultValue: core.constants.SOLO_CACHE_DIR,
     type: 'string'
   }
 }
@@ -191,7 +181,6 @@ export const nodeIDs = {
   name: 'node-ids',
   definition: {
     describe: 'Comma separated node IDs (empty means all nodes)',
-    default: '',
     alias: 'i',
     type: 'string'
   }
@@ -201,7 +190,7 @@ export const force = {
   name: 'force',
   definition: {
     describe: 'Force actions even if those can be skipped',
-    default: false,
+    defaultValue: false,
     alias: 'f',
     type: 'boolean'
   }
@@ -211,7 +200,7 @@ export const chartDirectory = {
   name: 'chart-dir',
   definition: {
     describe: 'Local chart directory path (e.g. ~/full-stack-testing/charts',
-    default: '',
+    defaultValue: '',
     alias: 'd',
     type: 'string'
   }
@@ -221,7 +210,7 @@ export const replicaCount = {
   name: 'replica-count',
   definition: {
     describe: 'Replica count',
-    default: 1,
+    defaultValue: 1,
     alias: '',
     type: 'number'
   }
@@ -231,7 +220,7 @@ export const chainId = {
   name: 'ledger-id',
   definition: {
     describe: 'Ledger ID (a.k.a. Chain ID)',
-    default: '298', // Ref: https://github.com/hashgraph/hedera-json-rpc-relay#configuration
+    defaultValue: '298', // Ref: https://github.com/hashgraph/hedera-json-rpc-relay#configuration
     alias: 'l',
     type: 'string'
   }
@@ -242,7 +231,7 @@ export const operatorId = {
   name: 'operator-id',
   definition: {
     describe: 'Operator ID',
-    default: constants.OPERATOR_ID,
+    defaultValue: constants.OPERATOR_ID,
     type: 'string'
   }
 }
@@ -252,7 +241,7 @@ export const operatorKey = {
   name: 'operator-key',
   definition: {
     describe: 'Operator Key',
-    default: constants.OPERATOR_KEY,
+    defaultValue: constants.OPERATOR_KEY,
     type: 'string'
   }
 }
@@ -261,7 +250,7 @@ export const generateGossipKeys = {
   name: 'gossip-keys',
   definition: {
     describe: 'Generate gossip keys for nodes',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -270,7 +259,7 @@ export const generateTlsKeys = {
   name: 'tls-keys',
   definition: {
     describe: 'Generate gRPC TLS keys for nodes',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -279,7 +268,7 @@ export const keyFormat = {
   name: 'key-format',
   definition: {
     describe: 'Public and Private key file format (pem or pfx)',
-    default: 'pfx',
+    defaultValue: 'pfx',
     type: 'string'
   }
 }
@@ -288,7 +277,7 @@ export const tlsClusterIssuerType = {
   name: 'tls-cluster-issuer-type',
   definition: {
     describe: 'The TLS cluster issuer type to use for hedera explorer, defaults to "self-signed", the available options are: "acme-staging", "acme-prod", or "self-signed"',
-    default: 'self-signed',
+    defaultValue: 'self-signed',
     type: 'string'
   }
 }
@@ -297,7 +286,7 @@ export const enableHederaExplorerTls = { // KEEP
   name: 'enable-hedera-explorer-tls',
   definition: {
     describe: 'Enable the Hedera Explorer TLS, defaults to false',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -306,7 +295,7 @@ export const hederaExplorerTlsLoadBalancerIp = {
   name: 'hedera-explorer-tls-load-balancer-ip',
   definition: {
     describe: 'The static IP address to use for the Hedera Explorer TLS load balancer, defaults to ""',
-    default: '',
+    defaultValue: '',
     type: 'string'
   }
 }
@@ -315,7 +304,7 @@ export const hederaExplorerTlsHostName = {
   name: 'hedera-explorer-tls-host-name',
   definition: {
     describe: 'The host name to use for the Hedera Explorer TLS, defaults to "explorer.fst.local"',
-    default: 'explorer.fst.local',
+    defaultValue: 'explorer.fst.local',
     type: 'string'
   }
 }
@@ -324,7 +313,7 @@ export const deletePvcs = {
   name: 'delete-pvcs',
   definition: {
     describe: 'Delete the persistent volume claims',
-    default: false,
+    defaultValue: false,
     type: 'boolean'
   }
 }
@@ -333,7 +322,7 @@ export const fstChartVersion = {
   name: 'fst-chart-version',
   definition: {
     describe: 'Fullstack testing chart version',
-    default: helpers.packageVersion(),
+    defaultValue: helpers.packageVersion(),
     type: 'string'
   }
 }
@@ -341,6 +330,7 @@ export const fstChartVersion = {
 export const allFlags = [
   devMode,
   clusterName,
+  clusterSetupNamespace,
   namespace,
   kubeContext,
   deployMirrorNode,
@@ -371,3 +361,5 @@ export const allFlags = [
   deletePvcs,
   fstChartVersion
 ]
+
+export const allFlagsMap = new Map(allFlags.map(f => [f.name, f]))

--- a/solo/src/commands/flags.mjs
+++ b/solo/src/commands/flags.mjs
@@ -152,7 +152,7 @@ export const releaseTag = {
   name: 'release-tag',
   definition: {
     describe: 'Release tag to be used (e.g. v0.42.5)',
-    default: 'v0.42.5',
+    default: '',
     alias: 't',
     type: 'string'
   }

--- a/solo/src/commands/flags.mjs
+++ b/solo/src/commands/flags.mjs
@@ -10,8 +10,19 @@ import * as helpers from '../core/helpers.mjs'
  */
 export function setCommandFlags (y, ...commandFlags) {
   commandFlags.forEach(flag => {
-    y.option(flag.name, flag.definition)
+    setCommandFlag(y, flag, false)
   })
+}
+
+export function setCommandFlag (y, flag, demand = false) {
+  if (demand) {
+    const def = JSON.parse(JSON.stringify(flag.definition))
+    delete (def.default)
+    def.demand = demand
+    y.option(flag.name, def)
+  } else {
+    y.option(flag.name, flag.definition)
+  }
 }
 
 export function withDefaultValue (f, value) {

--- a/solo/src/commands/init.mjs
+++ b/solo/src/commands/init.mjs
@@ -108,8 +108,13 @@ export class InitCommand extends BaseCommand {
       command: 'init',
       desc: 'Initialize local environment and default flags',
       builder: y => {
+        const requiredFlags = [flags.namespace.name, flags.releaseTag.name, flags.nodeIDs.name]
         for (const flag of flags.allFlags) {
-          flags.setCommandFlags(y, flag)
+          if (requiredFlags.includes(flag.name)) {
+            flags.setCommandFlag(y, flag, true)
+          } else {
+            flags.setCommandFlag(y, flag, false)
+          }
         }
       },
       handler: (argv) => {

--- a/solo/src/commands/init.mjs
+++ b/solo/src/commands/init.mjs
@@ -78,14 +78,11 @@ export class InitCommand extends BaseCommand {
         title: 'Setup chart manager',
         task: async (ctx, _) => {
           ctx.repoURLs = await this.chartManager.setup()
-        }
-      },
-      {
-        title: 'Generate status report',
-        task: (ctx, _) => {
-          self.logger.showList('Home Directories', ctx.dirs)
-          self.logger.showList('Chart Repository', ctx.repoURLs)
-          self.logger.showJSON('Cached Config', ctx.config)
+          if (argv.dev) {
+            self.logger.showList('Home Directories', ctx.dirs)
+            self.logger.showList('Chart Repository', ctx.repoURLs)
+            self.logger.showJSON('Cached Config', ctx.config)
+          }
         }
       }
     ], {

--- a/solo/src/commands/init.mjs
+++ b/solo/src/commands/init.mjs
@@ -108,14 +108,7 @@ export class InitCommand extends BaseCommand {
       command: 'init',
       desc: 'Initialize local environment and default flags',
       builder: y => {
-        const requiredFlags = [flags.namespace.name, flags.releaseTag.name, flags.nodeIDs.name]
-        for (const flag of flags.allFlags) {
-          if (requiredFlags.includes(flag.name)) {
-            flags.setCommandFlag(y, flag, true)
-          } else {
-            flags.setCommandFlag(y, flag, false)
-          }
-        }
+        flags.setCommandFlags(y, ...flags.allFlags)
       },
       handler: (argv) => {
         initCmd.init(argv).then(r => {

--- a/solo/src/commands/network.mjs
+++ b/solo/src/commands/network.mjs
@@ -75,7 +75,7 @@ export class NetworkCommand extends BaseCommand {
 
     // prepare name and account IDs for nodes
     let i = 0
-    let accountId = 3
+    let accountId = Number.parseInt(constants.HEDERA_NODE_ACCOUNT_ID_START)
     config.nodeIds.forEach(nodeId => {
       valuesArg += ` --set hedera.nodes[${i}].name=${nodeId},hedera.nodes[${i++}].accountId=0.0.${accountId++}`
     })

--- a/solo/src/commands/prompts.mjs
+++ b/solo/src/commands/prompts.mjs
@@ -27,9 +27,7 @@ export async function promptNamespace (task, input) {
 
 export async function promptNodeIds (task, input) {
   try {
-    let nodeIds = []
     if (!input) {
-      nodeIds = []
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'input',
         default: 'node0,node1,node2',
@@ -37,16 +35,7 @@ export async function promptNodeIds (task, input) {
       })
     }
 
-    if (input) {
-      input.split(',').forEach(item => {
-        const nodeId = item.trim()
-        if (nodeId) {
-          nodeIds.push(nodeId)
-        }
-      })
-    }
-
-    return nodeIds
+    return input
   } catch (e) {
     throw new FullstackTestingError(`input failed: ${flags.nodeIDs.name}`, e)
   }

--- a/solo/src/commands/prompts.mjs
+++ b/solo/src/commands/prompts.mjs
@@ -10,7 +10,7 @@ export async function promptNamespace (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.namespace.definition.default,
+        default: 'solo',
         message: 'Enter namespace name: '
       })
     }
@@ -22,6 +22,26 @@ export async function promptNamespace (task, input) {
     return input
   } catch (e) {
     throw new FullstackTestingError(`input failed: ${flags.namespace.name}: ${e.message}`, e)
+  }
+}
+
+export async function promptClusterSetupNamespace (task, input) {
+  try {
+    if (!input) {
+      input = await task.prompt(ListrEnquirerPromptAdapter).run({
+        type: 'text',
+        default: 'solo-cluster',
+        message: 'Enter cluster setup namespace name: '
+      })
+    }
+
+    if (!input) {
+      throw new FullstackTestingError('cluster setup namespace cannot be empty')
+    }
+
+    return input
+  } catch (e) {
+    throw new FullstackTestingError(`input failed: ${flags.clusterSetupNamespace.name}: ${e.message}`, e)
   }
 }
 
@@ -46,7 +66,7 @@ export async function promptReleaseTag (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.releaseTag.definition.default,
+        default: 'v0.42.5',
         message: 'Enter release version:'
       })
 
@@ -68,7 +88,7 @@ export async function promptRelayReleaseTag (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.relayReleaseTag.definition.default,
+        default: flags.relayReleaseTag.definition.defaultValue,
         message: 'Enter relay release version:'
       })
     }
@@ -79,7 +99,7 @@ export async function promptRelayReleaseTag (task, input) {
 
     return input
   } catch (e) {
-    throw new FullstackTestingError(`input failed for '${flags.releaseTag.name}': ${e.message}`, e)
+    throw new FullstackTestingError(`input failed for '${flags.relayReleaseTag.name}': ${e.message}`, e)
   }
 }
 
@@ -104,7 +124,7 @@ export async function promptForce (task, input) {
     if (typeof input !== 'boolean') {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.force.definition.default,
+        default: flags.force.definition.defaultValue,
         message: 'Would you like to force changes?'
       })
     }
@@ -120,7 +140,7 @@ export async function promptChainId (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.chainId.definition.default,
+        default: flags.chainId.definition.defaultValue,
         message: 'Enter chain ID: '
       })
     }
@@ -136,7 +156,7 @@ export async function promptChartDir (task, input) {
     if (input && !fs.existsSync(input)) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.chartDirectory.definition.default,
+        default: flags.chartDirectory.definition.defaultValue,
         message: 'Enter local charts directory path: '
       })
 
@@ -156,7 +176,7 @@ export async function promptValuesFile (task, input) {
     if (input && !fs.existsSync(input)) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.valuesFile.definition.default,
+        default: flags.valuesFile.definition.defaultValue,
         message: 'Enter path to values.yaml: '
       })
 
@@ -176,7 +196,7 @@ export async function promptDeployPrometheusStack (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deployPrometheusStack.definition.default,
+        default: flags.deployPrometheusStack.definition.defaultValue,
         message: 'Would you like to deploy prometheus stack?'
       })
     }
@@ -192,7 +212,7 @@ export async function promptEnablePrometheusSvcMonitor (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.enablePrometheusSvcMonitor.definition.default,
+        default: flags.enablePrometheusSvcMonitor.definition.defaultValue,
         message: 'Would you like to enable the Prometheus service monitor for the network nodes?'
       })
     }
@@ -208,7 +228,7 @@ export async function promptDeployMinio (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deployMinio.definition.default,
+        default: flags.deployMinio.definition.defaultValue,
         message: 'Would you like to deploy MinIO?'
       })
     }
@@ -224,7 +244,7 @@ export async function promptDeployCertManager (task, input) {
     if (typeof input !== 'boolean') {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deployCertManager.definition.default,
+        default: flags.deployCertManager.definition.defaultValue,
         message: 'Would you like to deploy Cert Manager?'
       })
     }
@@ -240,7 +260,7 @@ export async function promptDeployCertManagerCrds (task, input) {
     if (typeof input !== 'boolean') {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deployCertManagerCrds.definition.default,
+        default: flags.deployCertManagerCrds.definition.defaultValue,
         message: 'Would you like to deploy Cert Manager CRDs?'
       })
     }
@@ -256,7 +276,7 @@ export async function promptDeployMirrorNode (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deployMirrorNode.definition.default,
+        default: flags.deployMirrorNode.definition.defaultValue,
         message: 'Would you like to deploy Hedera Mirror Node?'
       })
     }
@@ -272,7 +292,7 @@ export async function promptDeployHederaExplorer (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deployHederaExplorer.definition.default,
+        default: flags.deployHederaExplorer.definition.defaultValue,
         message: 'Would you like to deploy Hedera Explorer?'
       })
     }
@@ -288,7 +308,7 @@ export async function promptTlsClusterIssuerType (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.tlsClusterIssuerType.definition.default,
+        default: flags.tlsClusterIssuerType.definition.defaultValue,
         message: 'Enter TLS cluster issuer type, available options are: "acme-staging", "acme-prod", or "self-signed":'
       })
     }
@@ -308,7 +328,7 @@ export async function promptEnableHederaExplorerTls (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.enableHederaExplorerTls.definition.default,
+        default: flags.enableHederaExplorerTls.definition.defaultValue,
         message: 'Would you like to enable the Hedera Explorer TLS?'
       })
     }
@@ -324,7 +344,7 @@ export async function promptHederaExplorerTlsHostName (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.hederaExplorerTlsHostName.definition.default,
+        default: flags.hederaExplorerTlsHostName.definition.defaultValue,
         message: 'Enter the host name to use for the Hedera Explorer TLS:'
       })
     }
@@ -340,7 +360,7 @@ export async function promptOperatorId (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.operatorId.definition.default,
+        default: flags.operatorId.definition.defaultValue,
         message: 'Enter operator ID: '
       })
     }
@@ -356,7 +376,7 @@ export async function promptOperatorKey (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.operatorKey.definition.default,
+        default: flags.operatorKey.definition.defaultValue,
         message: 'Enter operator ID: '
       })
     }
@@ -372,7 +392,7 @@ export async function promptReplicaCount (task, input) {
     if (typeof input !== 'number') {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'number',
-        default: flags.replicaCount.definition.default,
+        default: flags.replicaCount.definition.defaultValue,
         message: 'How many replica do you want?'
       })
     }
@@ -388,7 +408,7 @@ export async function promptGenerateGossipKeys (task, input) {
     if (typeof input !== 'boolean') {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.generateGossipKeys.definition.default,
+        default: flags.generateGossipKeys.definition.defaultValue,
         message: `Would you like to generate Gossip keys? ${typeof input} ${input}`
       })
     }
@@ -404,7 +424,7 @@ export async function promptGenerateTLSKeys (task, input) {
     if (typeof input !== 'boolean') {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.generateTlsKeys.definition.default,
+        default: flags.generateTlsKeys.definition.defaultValue,
         message: 'Would you like to generate TLS keys?'
       })
     }
@@ -420,7 +440,7 @@ export async function promptDeletePvcs (task, input) {
     if (input === undefined) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'toggle',
-        default: flags.deletePvcs.definition.default,
+        default: flags.deletePvcs.definition.defaultValue,
         message: 'Would you like to delete persistent volume claims upon uninstall?'
       })
     }
@@ -437,7 +457,7 @@ export async function promptKeyFormat (task, input, choices = [constants.KEY_FOR
     if (initial < 0) {
       const input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'select',
-        initial: choices.indexOf(flags.keyFormat.definition.default),
+        initial: choices.indexOf(flags.keyFormat.definition.defaultValue),
         message: 'Select key format',
         choices: helpers.cloneArray(choices)
       })
@@ -460,7 +480,7 @@ export async function promptFstChartVersion (task, input) {
     if (!input) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
         type: 'text',
-        default: flags.fstChartVersion.definition.default,
+        default: flags.fstChartVersion.definition.defaultValue,
         message: 'Enter fullstack testing chart version: '
       })
     }
@@ -476,6 +496,7 @@ export function getPromptMap () {
     .set(flags.nodeIDs.name, promptNodeIds)
     .set(flags.releaseTag.name, promptReleaseTag)
     .set(flags.relayReleaseTag.name, promptRelayReleaseTag)
+    .set(flags.clusterSetupNamespace.name, promptClusterSetupNamespace)
     .set(flags.namespace.name, promptNamespace)
     .set(flags.cacheDir.name, promptCacheDir)
     .set(flags.force.name, promptForce)

--- a/solo/src/core/config_manager.mjs
+++ b/solo/src/core/config_manager.mjs
@@ -98,13 +98,29 @@ export class ConfigManager {
 
           if (argv[flag.name] !== undefined) {
             let val = argv[flag.name]
-            if (val && (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name)) {
-              this.logger.debug(`Resolving directory path for '${flag.name}': ${val}`)
-              val = paths.resolve(val)
-            }
+            switch (flag.definition.type) {
+              case 'string':
+                if (val) {
+                  if (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name) {
+                    this.logger.debug(`Resolving directory path for '${flag.name}': ${val}`)
+                    val = paths.resolve(val)
+                  }
+                  this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
+                  config.flags[flag.name] = val
+                  writeConfig = true
+                }
+                break
 
-            config.flags[flag.name] = val
-            writeConfig = true
+              case 'number':
+              case 'boolean':
+                this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
+                config.flags[flag.name] = val
+                writeConfig = true
+                break
+
+              default:
+                throw new FullstackTestingError(`Unsupported field type for flag '${flag.name}': ${flag.definition.type}`)
+            }
           }
         }
 

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -77,6 +77,7 @@ export const LISTR_DEFAULT_RENDERER_TIMER_OPTION = {
 }
 
 export const LISTR_DEFAULT_RENDERER_OPTION = {
+  collapseSubtasks: false,
   timer: LISTR_DEFAULT_RENDERER_TIMER_OPTION
 }
 

--- a/solo/src/core/helpers.mjs
+++ b/solo/src/core/helpers.mjs
@@ -5,10 +5,27 @@ import { fileURLToPath } from 'url'
 
 // cache current directory
 const CUR_FILE_DIR = paths.dirname(fileURLToPath(import.meta.url))
+
 export function sleep (ms) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms)
   })
+}
+
+export function parseNodeIDs (input) {
+  if (typeof input === 'string') {
+    const nodeIds = []
+    input.split(',').forEach(item => {
+      const nodeId = item.trim()
+      if (nodeId) {
+        nodeIds.push(nodeId)
+      }
+    })
+
+    return nodeIds
+  }
+
+  throw new FullstackTestingError('node IDs is not a comma separated string')
 }
 
 export function cloneArray (arr) {

--- a/solo/src/core/logging.mjs
+++ b/solo/src/core/logging.mjs
@@ -68,7 +68,7 @@ export const Logger = class {
   }
 
   setDevMode (devMode) {
-    this.debug(`setting dev mode: ${devMode}`)
+    this.debug(`dev mode logging: ${devMode}`)
     this.devMode = devMode
   }
 

--- a/solo/src/index.mjs
+++ b/solo/src/index.mjs
@@ -34,7 +34,7 @@ export function main (argv) {
     const kubeConfig = k8.getKubeConfig()
     const context = kubeConfig.getContextObject(kubeConfig.getCurrentContext())
     const cluster = kubeConfig.getCurrentCluster()
-    configManager.load()
+    const config = configManager.load()
     configManager.setFlag(flags.clusterName, cluster.name)
     if (context.namespace) {
       configManager.setFlag(flags.namespace, context.namespace)
@@ -60,6 +60,22 @@ export function main (argv) {
       keyManager
     }
 
+    const processArguments = (args, yargs) => {
+      for (const key of Object.keys(yargs.parsed.aliases)) {
+        const flag = flags.allFlagsMap.get(key)
+        if (flag) {
+          if (args[key]) {
+            // argv takes precedence
+          } else if (config.flags[key]) {
+            args[key] = config.flags[key]
+          } else if (args._[0] !== "init") {
+            args[key] = flag.definition.defaultValue
+          }
+        }
+      }
+      return args
+    }
+
     return yargs(hideBin(argv))
       .usage('Usage:\n  $0 <command> [options]')
       .alias('h', 'help')
@@ -69,6 +85,7 @@ export function main (argv) {
       .option(flags.devMode.name, flags.devMode.definition)
       .wrap(120)
       .demand(1, 'Select a command')
+      .middleware(processArguments, true)
       .parse()
   } catch (e) {
     logger.showUserError(e)

--- a/solo/test/e2e/setup-e2e.sh
+++ b/solo/test/e2e/setup-e2e.sh
@@ -4,6 +4,6 @@ SOLO_NAMESPACE=solo-local
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" || exit 1
 kubectl create ns "${SOLO_NAMESPACE}" || exit 1
-solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 || exit 1 # cache args for subsequent commands
+solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 solo network deploy || exit 1

--- a/solo/test/e2e/setup-e2e.sh
+++ b/solo/test/e2e/setup-e2e.sh
@@ -4,6 +4,6 @@ SOLO_NAMESPACE=solo-local
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" || exit 1
 kubectl create ns "${SOLO_NAMESPACE}" || exit 1
-solo init -d ../charts --namespace "${SOLO_NAMESPACE}" || exit 1 # cache args for subsequent commands
+solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -n node0,node1,node2 || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 solo network deploy || exit 1

--- a/solo/test/e2e/setup-e2e.sh
+++ b/solo/test/e2e/setup-e2e.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-SOLO_CLUSTER_NAME=solo-local
-SOLO_NAMESPACE=solo-local
+SOLO_CLUSTER_NAME=solo-e2e
+SOLO_NAMESPACE=solo-e2e
+SOLO_CLUSTER_SETUP_NAMESPACE=solo-e2e-cluster
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" || exit 1
 kubectl create ns "${SOLO_NAMESPACE}" || exit 1
-solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 || exit 1 # cache args for subsequent commands
+kubectl create ns "${SOLO_CLUSTER_SETUP_NAMESPACE}" || exit 1
+solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 solo network deploy || exit 1

--- a/solo/test/e2e/setup-e2e.sh
+++ b/solo/test/e2e/setup-e2e.sh
@@ -4,6 +4,6 @@ SOLO_NAMESPACE=solo-local
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" || exit 1
 kubectl create ns "${SOLO_NAMESPACE}" || exit 1
-solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -n node0,node1,node2 || exit 1 # cache args for subsequent commands
+solo init -d ../charts --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 solo network deploy || exit 1


### PR DESCRIPTION
## Description
We can now just set the node IDs to deploy different number of network nodes, 
e.g. `solo network deploy -i node0,node1,node2,node3,node4......nodeN`

This pull request changes the following:

- allow deploying different number network nodes
- only output extra logs if `--dev` flag is set
- updated solo README with console output logs for reference

### Related Issues

- Closes #582
