### PR TITLE
feat: rekey special accounts at startup so they are not using genesis keys

### DIFF
--- a/charts/fullstack-deployment/config-files/haproxy.cfg
+++ b/charts/fullstack-deployment/config-files/haproxy.cfg
@@ -1,5 +1,5 @@
 global
-    log 127.0.0.1 local0 info
+    log stdout local0 debug
     maxconn 100000
     ssl-default-bind-ciphers ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS
     ssl-default-bind-options ssl-min-ver TLSv1.1

--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -37,6 +37,7 @@ spec:
         app: network-{{ $node.name }}
         fullstack.hedera.com/type: network-node
         fullstack.hedera.com/node-name: {{ $node.name }}
+        fullstack.hedera.com/account-id: {{ $node.accountId }}
         {{- include "fullstack.testLabels" $ | nindent 8 }}
     spec:
       {{- if $.Values.deployment.nodeSelector }}

--- a/charts/fullstack-deployment/templates/services/haproxy-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/haproxy-svc.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     fullstack.hedera.com/type: haproxy-svc
     fullstack.hedera.com/node-name: {{ $node.name }}
+    fullstack.hedera.com/account-id: {{ $node.accountId }}
     fullstack.hedera.com/prometheus-endpoint: active
     {{- include "fullstack.testLabels" $ | nindent 4 }}
 spec:

--- a/solo/src/commands/base.mjs
+++ b/solo/src/commands/base.mjs
@@ -39,6 +39,7 @@ export class BaseCommand extends ShellRunner {
     if (!opts || !opts.chartManager) throw new Error('An instance of core/ChartManager is required')
     if (!opts || !opts.configManager) throw new Error('An instance of core/ConfigManager is required')
     if (!opts || !opts.depManager) throw new Error('An instance of core/DependencyManager is required')
+    if (!opts || !opts.accountManager) throw new Error('An instance of core/AccountManager is required')
 
     super(opts.logger)
 
@@ -47,5 +48,6 @@ export class BaseCommand extends ShellRunner {
     this.chartManager = opts.chartManager
     this.configManager = opts.configManager
     this.depManager = opts.depManager
+    this.accountManager = opts.accountManager
   }
 }

--- a/solo/src/commands/base.mjs
+++ b/solo/src/commands/base.mjs
@@ -39,7 +39,6 @@ export class BaseCommand extends ShellRunner {
     if (!opts || !opts.chartManager) throw new Error('An instance of core/ChartManager is required')
     if (!opts || !opts.configManager) throw new Error('An instance of core/ConfigManager is required')
     if (!opts || !opts.depManager) throw new Error('An instance of core/DependencyManager is required')
-    if (!opts || !opts.accountManager) throw new Error('An instance of core/AccountManager is required')
 
     super(opts.logger)
 
@@ -48,6 +47,5 @@ export class BaseCommand extends ShellRunner {
     this.chartManager = opts.chartManager
     this.configManager = opts.configManager
     this.depManager = opts.depManager
-    this.accountManager = opts.accountManager
   }
 }

--- a/solo/src/commands/flags.mjs
+++ b/solo/src/commands/flags.mjs
@@ -379,6 +379,15 @@ export const log4j2Xml = {
   }
 }
 
+export const updateAccountKeys = {
+  name: 'update-account-keys',
+  definition: {
+    describe: 'Updates the special account keys to new keys and stores their keys in a corresponding Kubernetes secret',
+    defaultValue: true,
+    type: 'boolean'
+  }
+}
+
 export const allFlags = [
   devMode,
   clusterName,
@@ -415,7 +424,8 @@ export const allFlags = [
   apiPermissionProperties,
   bootstrapProperties,
   settingTxt,
-  log4j2Xml
+  log4j2Xml,
+  updateAccountKeys
 ]
 
 export const allFlagsMap = new Map(allFlags.map(f => [f.name, f]))

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -36,10 +36,12 @@ export class NodeCommand extends BaseCommand {
     if (!opts || !opts.downloader) throw new IllegalArgumentError('An instance of core/PackageDowner is required', opts.downloader)
     if (!opts || !opts.platformInstaller) throw new IllegalArgumentError('An instance of core/PlatformInstaller is required', opts.platformInstaller)
     if (!opts || !opts.keyManager) throw new IllegalArgumentError('An instance of core/KeyManager is required', opts.keyManager)
+    if (!opts || !opts.accountManager) throw new IllegalArgumentError('An instance of core/AccountManager is required', opts.accountManager)
 
     this.downloader = opts.downloader
     this.plaformInstaller = opts.platformInstaller
     this.keyManager = opts.keyManager
+    this.accountManager = opts.accountManager
   }
 
   async checkNetworkNodePod (namespace, nodeId) {
@@ -777,27 +779,28 @@ export class NodeCommand extends BaseCommand {
               })
             }
           })
-        .command({
-          command: 'jeromy',
-          desc: 'update all of the account keys',
-          builder: y => flags.setCommandFlags(y,
+          .command({
+            command: 'jeromy',
+            desc: 'update all of the account keys',
+            builder: y => flags.setCommandFlags(y,
               flags.namespace,
               flags.nodeIDs
-          ),
-          handler: argv => {
-            nodeCmd.logger.debug("==== Running 'node keys' ===")
-            nodeCmd.logger.debug(argv)
-            nodeCmd.jeromyTesting(argv)
-          }
-        })
+            ),
+            handler: argv => {
+              nodeCmd.logger.debug("==== Running 'node keys' ===")
+              nodeCmd.logger.debug(argv)
+              nodeCmd.jeromyTesting(argv)
+            }
+          })
           .demandCommand(1, 'Select a node command')
       }
     }
   }
-  jeromyTesting(argv) {
-    this.k8.jeromyTesting(argv).then( r => {
-          console.log(`result: ${JSON.stringify(r)}`)
-        }
+
+  jeromyTesting (argv) {
+    this.accountManager.jeromyTesting(argv).then(r => {
+      console.log(`result: ${JSON.stringify(r)}`)
+    }
     ).catch(err => {
       console.log(`error: ${JSON.stringify(err)}`)
     })

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -777,8 +777,29 @@ export class NodeCommand extends BaseCommand {
               })
             }
           })
+        .command({
+          command: 'jeromy',
+          desc: 'update all of the account keys',
+          builder: y => flags.setCommandFlags(y,
+              flags.namespace,
+              flags.nodeIDs
+          ),
+          handler: argv => {
+            nodeCmd.logger.debug("==== Running 'node keys' ===")
+            nodeCmd.logger.debug(argv)
+            nodeCmd.jeromyTesting(argv)
+          }
+        })
           .demandCommand(1, 'Select a node command')
       }
     }
+  }
+  jeromyTesting(argv) {
+    this.k8.jeromyTesting(argv).then( r => {
+          console.log(`result: ${JSON.stringify(r)}`)
+        }
+    ).catch(err => {
+      console.log(`error: ${JSON.stringify(err)}`)
+    })
   }
 }

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -67,6 +67,8 @@ export class NodeCommand extends BaseCommand {
     let attempt = 0
     let isActive = false
 
+    await sleep(10000) // sleep in case this the user ran the start command again at a later time
+
     // check log file is accessible
     let logFileAccessible = false
     while (attempt++ < maxAttempt) {
@@ -88,7 +90,7 @@ export class NodeCommand extends BaseCommand {
     while (attempt < maxAttempt) {
       try {
         const output = await this.k8.execContainer(podName, constants.ROOT_CONTAINER, ['tail', '-10', logfilePath])
-        if (output.indexOf(`Terminating Netty = ${status}`) < 0 &&
+        if (output.indexOf(`Terminating Netty = ${status}`) < 0 && // make sure we are not at the beginning of a restart
             output.indexOf(`Now current platform status = ${status}`) > 0) {
           this.logger.debug(`Node ${nodeId} is ${status} [ attempt: ${attempt}/${maxAttempt}]`)
           isActive = true
@@ -107,6 +109,8 @@ export class NodeCommand extends BaseCommand {
       attempt += 1
       await sleep(1000)
     }
+
+    this.logger.info(`!> -- Node ${nodeId} is ${status} -- <!`)
 
     if (!isActive) {
       throw new FullstackTestingError(`node '${nodeId}' is not ${status} [ attempt = ${attempt}/${maxAttempt} ]`)

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -88,7 +88,8 @@ export class NodeCommand extends BaseCommand {
     while (attempt < maxAttempt) {
       try {
         const output = await this.k8.execContainer(podName, constants.ROOT_CONTAINER, ['tail', '-10', logfilePath])
-        if (output.indexOf(`Now current platform status = ${status}`) > 0) {
+        if (output.indexOf(`Terminating Netty = ${status}`) < 0 &&
+            output.indexOf(`Now current platform status = ${status}`) > 0) {
           this.logger.debug(`Node ${nodeId} is ${status} [ attempt: ${attempt}/${maxAttempt}]`)
           isActive = true
           break
@@ -479,7 +480,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Update special account keys',
         task: async (ctx, task) => {
-          await self.accountManager.prepareAccount(ctx.config.namespace)
+          await self.accountManager.prepareAccounts(ctx.config.namespace)
         }
       }
     ], {
@@ -785,37 +786,8 @@ export class NodeCommand extends BaseCommand {
               })
             }
           })
-          .command({ // TODO remove
-            command: 'jeromy',
-            desc: 'update all of the account keys',
-            builder: y => flags.setCommandFlags(y,
-              flags.namespace,
-              flags.nodeIDs
-            ),
-            handler: argv => {
-              nodeCmd.logger.debug("==== Running 'node keys' ===")
-              nodeCmd.logger.debug(argv)
-              nodeCmd.jeromyTesting(argv)
-            }
-          })
           .demandCommand(1, 'Select a node command')
       }
     }
-  }
-
-  // TODO remove
-  jeromyTesting (argv) {
-    // this.accountManager.jeromyTesting(argv).then(r => {
-    //   r.serviceMap.forEach(value => console.log(JSON.stringify(value)))
-    //   console.log(`basePath: ${JSON.stringify(r.basePath)}`)
-    // }
-    // ).catch(err => {
-    //   console.log(`error: ${JSON.stringify(err)}`)
-    // })
-    this.accountManager.prepareAccount(argv.namespace).then(
-      this.logger.debug('prepareAccount successful')
-    ).catch(err => {
-      this.logger.error(`error: ${JSON.stringify(err)}`)
-    })
   }
 }

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -799,7 +799,8 @@ export class NodeCommand extends BaseCommand {
 
   jeromyTesting (argv) {
     this.accountManager.jeromyTesting(argv).then(r => {
-      console.log(`result: ${JSON.stringify(r)}`)
+      r.serviceMap.forEach(value => console.log(JSON.stringify(value)))
+      console.log(`basePath: ${JSON.stringify(r.basePath)}`)
     }
     ).catch(err => {
       console.log(`error: ${JSON.stringify(err)}`)

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -785,7 +785,7 @@ export class NodeCommand extends BaseCommand {
               })
             }
           })
-          .command({
+          .command({ // TODO remove
             command: 'jeromy',
             desc: 'update all of the account keys',
             builder: y => flags.setCommandFlags(y,
@@ -803,6 +803,7 @@ export class NodeCommand extends BaseCommand {
     }
   }
 
+  // TODO remove
   jeromyTesting (argv) {
     // this.accountManager.jeromyTesting(argv).then(r => {
     //   r.serviceMap.forEach(value => console.log(JSON.stringify(value)))

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -25,6 +25,7 @@ import { constants, Templates } from '../core/index.mjs'
 import { BaseCommand } from './base.mjs'
 import * as flags from './flags.mjs'
 import * as prompts from './prompts.mjs'
+import { updateAccountKeys } from './flags.mjs'
 
 /**
  * Defines the core functionalities of 'node' command
@@ -419,12 +420,14 @@ export class NodeCommand extends BaseCommand {
           self.configManager.load(argv)
           await prompts.execute(task, self.configManager, [
             flags.namespace,
-            flags.nodeIDs
+            flags.nodeIDs,
+            flags.updateAccountKeys
           ])
 
           ctx.config = {
             namespace: self.configManager.getFlag(flags.namespace),
-            nodeIds: helpers.parseNodeIDs(self.configManager.getFlag(flags.nodeIDs))
+            nodeIds: helpers.parseNodeIDs(self.configManager.getFlag(flags.nodeIDs)),
+            updateAccountKeys: self.configManager.getFlag(flags.updateAccountKeys)
           }
 
           if (!await this.k8.hasNamespace(ctx.config.namespace)) {
@@ -484,7 +487,9 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Update special account keys',
         task: async (ctx, task) => {
-          await self.accountManager.prepareAccounts(ctx.config.namespace)
+          if (ctx.config.updateAccountKeys) {
+            await self.accountManager.prepareAccounts(ctx.config.namespace)
+          }
         }
       }
     ], {
@@ -732,7 +737,8 @@ export class NodeCommand extends BaseCommand {
             desc: 'Start a node',
             builder: y => flags.setCommandFlags(y,
               flags.namespace,
-              flags.nodeIDs
+              flags.nodeIDs,
+              flags.updateAccountKeys
             ),
             handler: argv => {
               nodeCmd.logger.debug("==== Running 'node start' ===")

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -25,7 +25,6 @@ import { constants, Templates } from '../core/index.mjs'
 import { BaseCommand } from './base.mjs'
 import * as flags from './flags.mjs'
 import * as prompts from './prompts.mjs'
-import { updateAccountKeys } from './flags.mjs'
 
 /**
  * Defines the core functionalities of 'node' command
@@ -489,6 +488,9 @@ export class NodeCommand extends BaseCommand {
         task: async (ctx, task) => {
           if (ctx.config.updateAccountKeys) {
             await self.accountManager.prepareAccounts(ctx.config.namespace)
+          } else {
+            this.logger.showUser(chalk.yellowBright('> WARNING:'), chalk.yellow(
+              'skipping special account keys update, special accounts will retain genesis private keys'))
           }
         }
       }

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -475,6 +475,12 @@ export class NodeCommand extends BaseCommand {
             }
           })
         }
+      },
+      {
+        title: 'Update special account keys',
+        task: async (ctx, task) => {
+          await self.accountManager.prepareAccount(ctx.config.namespace)
+        }
       }
     ], {
       concurrent: false,
@@ -798,12 +804,17 @@ export class NodeCommand extends BaseCommand {
   }
 
   jeromyTesting (argv) {
-    this.accountManager.jeromyTesting(argv).then(r => {
-      r.serviceMap.forEach(value => console.log(JSON.stringify(value)))
-      console.log(`basePath: ${JSON.stringify(r.basePath)}`)
-    }
+    // this.accountManager.jeromyTesting(argv).then(r => {
+    //   r.serviceMap.forEach(value => console.log(JSON.stringify(value)))
+    //   console.log(`basePath: ${JSON.stringify(r.basePath)}`)
+    // }
+    // ).catch(err => {
+    //   console.log(`error: ${JSON.stringify(err)}`)
+    // })
+    this.accountManager.prepareAccount(argv.namespace).then(
+      this.logger.debug('prepareAccount successful')
     ).catch(err => {
-      console.log(`error: ${JSON.stringify(err)}`)
+      this.logger.error(`error: ${JSON.stringify(err)}`)
     })
   }
 }

--- a/solo/src/commands/prompts.mjs
+++ b/solo/src/commands/prompts.mjs
@@ -50,9 +50,7 @@ async function promptToggle (task, input, defaultValue, promptMessage, emptyChec
 }
 
 export async function promptNamespace (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     'solo',
     'Enter namespace name: ',
     'namespace cannot be empty',
@@ -60,9 +58,7 @@ export async function promptNamespace (task, input) {
 }
 
 export async function promptClusterSetupNamespace (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     'solo-cluster',
     'Enter cluster setup namespace name: ',
     'cluster setup namespace cannot be empty',
@@ -70,10 +66,7 @@ export async function promptClusterSetupNamespace (task, input) {
 }
 
 export async function promptNodeIds (task, input) {
-  return await prompt(
-    'input',
-    task,
-    input,
+  return await prompt('input', task, input,
     'node0,node1,node2',
     'Enter list of node IDs (comma separated list): ',
     null,
@@ -81,9 +74,7 @@ export async function promptNodeIds (task, input) {
 }
 
 export async function promptReleaseTag (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     'v0.42.5',
     'Enter release version: ',
     'release tag cannot be empty',
@@ -91,9 +82,7 @@ export async function promptReleaseTag (task, input) {
 }
 
 export async function promptRelayReleaseTag (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     flags.relayReleaseTag.definition.defaultValue,
     'Enter relay release version: ',
     'relay-release-tag cannot be empty',
@@ -101,9 +90,7 @@ export async function promptRelayReleaseTag (task, input) {
 }
 
 export async function promptCacheDir (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     constants.SOLO_CACHE_DIR,
     'Enter local cache directory path: ',
     null,
@@ -111,9 +98,7 @@ export async function promptCacheDir (task, input) {
 }
 
 export async function promptForce (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.force.definition.defaultValue,
     'Would you like to force changes? ',
     null,
@@ -121,9 +106,7 @@ export async function promptForce (task, input) {
 }
 
 export async function promptChainId (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     flags.chainId.definition.defaultValue,
     'Enter chain ID: ',
     null,
@@ -171,9 +154,7 @@ export async function promptValuesFile (task, input) {
 }
 
 export async function promptDeployPrometheusStack (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deployPrometheusStack.definition.defaultValue,
     'Would you like to deploy prometheus stack? ',
     null,
@@ -181,9 +162,7 @@ export async function promptDeployPrometheusStack (task, input) {
 }
 
 export async function promptEnablePrometheusSvcMonitor (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.enablePrometheusSvcMonitor.definition.defaultValue,
     'Would you like to enable the Prometheus service monitor for the network nodes? ',
     null,
@@ -191,9 +170,7 @@ export async function promptEnablePrometheusSvcMonitor (task, input) {
 }
 
 export async function promptDeployMinio (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deployMinio.definition.defaultValue,
     'Would you like to deploy MinIO? ',
     null,
@@ -201,9 +178,7 @@ export async function promptDeployMinio (task, input) {
 }
 
 export async function promptDeployCertManager (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deployCertManager.definition.defaultValue,
     'Would you like to deploy Cert Manager? ',
     null,
@@ -211,9 +186,7 @@ export async function promptDeployCertManager (task, input) {
 }
 
 export async function promptDeployCertManagerCrds (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deployCertManagerCrds.definition.defaultValue,
     'Would you like to deploy Cert Manager CRDs? ',
     null,
@@ -221,9 +194,7 @@ export async function promptDeployCertManagerCrds (task, input) {
 }
 
 export async function promptDeployMirrorNode (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deployMirrorNode.definition.defaultValue,
     'Would you like to deploy Hedera Mirror Node? ',
     null,
@@ -231,9 +202,7 @@ export async function promptDeployMirrorNode (task, input) {
 }
 
 export async function promptDeployHederaExplorer (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deployHederaExplorer.definition.defaultValue,
     'Would you like to deploy Hedera Explorer? ',
     null,
@@ -261,9 +230,7 @@ export async function promptTlsClusterIssuerType (task, input) {
 }
 
 export async function promptEnableHederaExplorerTls (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.enableHederaExplorerTls.definition.defaultValue,
     'Would you like to enable the Hedera Explorer TLS? ',
     null,
@@ -271,9 +238,7 @@ export async function promptEnableHederaExplorerTls (task, input) {
 }
 
 export async function promptHederaExplorerTlsHostName (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     flags.hederaExplorerTlsHostName.definition.defaultValue,
     'Enter the host name to use for the Hedera Explorer TLS: ',
     null,
@@ -281,9 +246,7 @@ export async function promptHederaExplorerTlsHostName (task, input) {
 }
 
 export async function promptOperatorId (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     flags.operatorId.definition.defaultValue,
     'Enter operator ID: ',
     null,
@@ -291,9 +254,7 @@ export async function promptOperatorId (task, input) {
 }
 
 export async function promptOperatorKey (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     flags.operatorKey.definition.defaultValue,
     'Enter operator private key: ',
     null,
@@ -317,9 +278,7 @@ export async function promptReplicaCount (task, input) {
 }
 
 export async function promptGenerateGossipKeys (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.generateGossipKeys.definition.defaultValue,
     `Would you like to generate Gossip keys? ${typeof input} ${input} `,
     null,
@@ -327,9 +286,7 @@ export async function promptGenerateGossipKeys (task, input) {
 }
 
 export async function promptGenerateTLSKeys (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.generateTlsKeys.definition.defaultValue,
     'Would you like to generate TLS keys? ',
     null,
@@ -337,9 +294,7 @@ export async function promptGenerateTLSKeys (task, input) {
 }
 
 export async function promptDeletePvcs (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.deletePvcs.definition.defaultValue,
     'Would you like to delete persistent volume claims upon uninstall? ',
     null,
@@ -371,9 +326,7 @@ export async function promptKeyFormat (task, input, choices = [constants.KEY_FOR
 }
 
 export async function promptFstChartVersion (task, input) {
-  return await promptText(
-    task,
-    input,
+  return await promptText(task, input,
     flags.fstChartVersion.definition.defaultValue,
     'Enter fullstack testing chart version: ',
     null,
@@ -381,9 +334,7 @@ export async function promptFstChartVersion (task, input) {
 }
 
 export async function promptUpdateAccountKeys (task, input) {
-  return await promptToggle(
-    task,
-    input,
+  return await promptToggle(task, input,
     flags.updateAccountKeys.definition.defaultValue,
     'Would you like to updates the special account keys to new keys and stores their keys in a corresponding Kubernetes secret? ',
     null,

--- a/solo/src/commands/prompts.mjs
+++ b/solo/src/commands/prompts.mjs
@@ -21,150 +21,113 @@ import { constants } from '../core/index.mjs'
 import * as flags from './flags.mjs'
 import * as helpers from '../core/helpers.mjs'
 
-export async function promptNamespace (task, input) {
+async function prompt (type, task, input, defaultValue, promptMessage, emptyCheckMessage, flagName) {
   try {
-    if (!input) {
+    const needsPrompt = type === 'toggle' ? (input === undefined || typeof input !== 'boolean') : !input
+    if (needsPrompt) {
       input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: 'solo',
-        message: 'Enter namespace name: '
+        type,
+        default: defaultValue,
+        message: promptMessage
       })
     }
 
-    if (!input) {
-      throw new FullstackTestingError('namespace cannot be empty')
+    if (emptyCheckMessage && !input) {
+      throw new FullstackTestingError(emptyCheckMessage)
     }
 
     return input
   } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.namespace.name}: ${e.message}`, e)
+    throw new FullstackTestingError(`input failed: ${flagName}: ${e.message}`, e)
   }
+}
+async function promptText (task, input, defaultValue, promptMessage, emptyCheckMessage, flagName) {
+  return await prompt('text', task, input, defaultValue, promptMessage, emptyCheckMessage, flagName)
+}
+
+async function promptToggle (task, input, defaultValue, promptMessage, emptyCheckMessage, flagName) {
+  return await prompt('toggle', task, input, defaultValue, promptMessage, emptyCheckMessage, flagName)
+}
+
+export async function promptNamespace (task, input) {
+  return await promptText(
+    task,
+    input,
+    'solo',
+    'Enter namespace name: ',
+    'namespace cannot be empty',
+    flags.namespace.name)
 }
 
 export async function promptClusterSetupNamespace (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: 'solo-cluster',
-        message: 'Enter cluster setup namespace name: '
-      })
-    }
-
-    if (!input) {
-      throw new FullstackTestingError('cluster setup namespace cannot be empty')
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.clusterSetupNamespace.name}: ${e.message}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    'solo-cluster',
+    'Enter cluster setup namespace name: ',
+    'cluster setup namespace cannot be empty',
+    flags.clusterSetupNamespace.name)
 }
 
 export async function promptNodeIds (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'input',
-        default: 'node0,node1,node2',
-        message: 'Enter list of node IDs (comma separated list):'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.nodeIDs.name}`, e)
-  }
+  return await prompt(
+    'input',
+    task,
+    input,
+    'node0,node1,node2',
+    'Enter list of node IDs (comma separated list): ',
+    null,
+    flags.nodeIDs.name)
 }
 
 export async function promptReleaseTag (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: 'v0.42.5',
-        message: 'Enter release version:'
-      })
-
-      if (!input) throw new IllegalArgumentError('release tag cannot be empty')
-    }
-
-    if (!input) {
-      throw new FullstackTestingError('release-tag cannot be empty')
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.releaseTag.name}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    'v0.42.5',
+    'Enter release version: ',
+    'release tag cannot be empty',
+    flags.releaseTag.name)
 }
 
 export async function promptRelayReleaseTag (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: flags.relayReleaseTag.definition.defaultValue,
-        message: 'Enter relay release version:'
-      })
-    }
-
-    if (!input) {
-      throw new FullstackTestingError('relay-release-tag cannot be empty')
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed for '${flags.relayReleaseTag.name}': ${e.message}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    flags.relayReleaseTag.definition.defaultValue,
+    'Enter relay release version: ',
+    'relay-release-tag cannot be empty',
+    flags.relayReleaseTag.name)
 }
 
 export async function promptCacheDir (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: constants.SOLO_CACHE_DIR,
-        message: 'Enter local cache directory path:'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.cacheDir.name}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    constants.SOLO_CACHE_DIR,
+    'Enter local cache directory path: ',
+    null,
+    flags.cacheDir.name)
 }
 
 export async function promptForce (task, input) {
-  try {
-    if (typeof input !== 'boolean') {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.force.definition.defaultValue,
-        message: 'Would you like to force changes?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.force.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.force.definition.defaultValue,
+    'Would you like to force changes? ',
+    null,
+    flags.force.name)
 }
 
 export async function promptChainId (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: flags.chainId.definition.defaultValue,
-        message: 'Enter chain ID: '
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.chainId.name}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    flags.chainId.definition.defaultValue,
+    'Enter chain ID: ',
+    null,
+    flags.chainId.name)
 }
 
 export async function promptChartDir (task, input) {
@@ -208,115 +171,73 @@ export async function promptValuesFile (task, input) {
 }
 
 export async function promptDeployPrometheusStack (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deployPrometheusStack.definition.defaultValue,
-        message: 'Would you like to deploy prometheus stack?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployPrometheusStack.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deployPrometheusStack.definition.defaultValue,
+    'Would you like to deploy prometheus stack? ',
+    null,
+    flags.deployPrometheusStack.name)
 }
 
 export async function promptEnablePrometheusSvcMonitor (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.enablePrometheusSvcMonitor.definition.defaultValue,
-        message: 'Would you like to enable the Prometheus service monitor for the network nodes?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.enablePrometheusSvcMonitor.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.enablePrometheusSvcMonitor.definition.defaultValue,
+    'Would you like to enable the Prometheus service monitor for the network nodes? ',
+    null,
+    flags.enablePrometheusSvcMonitor.name)
 }
 
 export async function promptDeployMinio (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deployMinio.definition.defaultValue,
-        message: 'Would you like to deploy MinIO?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployMinio.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deployMinio.definition.defaultValue,
+    'Would you like to deploy MinIO? ',
+    null,
+    flags.deployMinio.name)
 }
 
 export async function promptDeployCertManager (task, input) {
-  try {
-    if (typeof input !== 'boolean') {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deployCertManager.definition.defaultValue,
-        message: 'Would you like to deploy Cert Manager?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployCertManager.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deployCertManager.definition.defaultValue,
+    'Would you like to deploy Cert Manager? ',
+    null,
+    flags.deployCertManager.name)
 }
 
 export async function promptDeployCertManagerCrds (task, input) {
-  try {
-    if (typeof input !== 'boolean') {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deployCertManagerCrds.definition.defaultValue,
-        message: 'Would you like to deploy Cert Manager CRDs?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployCertManagerCrds.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deployCertManagerCrds.definition.defaultValue,
+    'Would you like to deploy Cert Manager CRDs? ',
+    null,
+    flags.deployCertManagerCrds.name)
 }
 
 export async function promptDeployMirrorNode (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deployMirrorNode.definition.defaultValue,
-        message: 'Would you like to deploy Hedera Mirror Node?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployMirrorNode.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deployMirrorNode.definition.defaultValue,
+    'Would you like to deploy Hedera Mirror Node? ',
+    null,
+    flags.deployMirrorNode.name)
 }
 
 export async function promptDeployHederaExplorer (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deployHederaExplorer.definition.defaultValue,
-        message: 'Would you like to deploy Hedera Explorer?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployHederaExplorer.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deployHederaExplorer.definition.defaultValue,
+    'Would you like to deploy Hedera Explorer? ',
+    null,
+    flags.deployHederaExplorer.name)
 }
 
 export async function promptTlsClusterIssuerType (task, input) {
@@ -340,67 +261,43 @@ export async function promptTlsClusterIssuerType (task, input) {
 }
 
 export async function promptEnableHederaExplorerTls (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.enableHederaExplorerTls.definition.defaultValue,
-        message: 'Would you like to enable the Hedera Explorer TLS?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.enableHederaExplorerTls.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.enableHederaExplorerTls.definition.defaultValue,
+    'Would you like to enable the Hedera Explorer TLS? ',
+    null,
+    flags.enableHederaExplorerTls.name)
 }
 
 export async function promptHederaExplorerTlsHostName (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: flags.hederaExplorerTlsHostName.definition.defaultValue,
-        message: 'Enter the host name to use for the Hedera Explorer TLS:'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.hederaExplorerTlsHostName.name}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    flags.hederaExplorerTlsHostName.definition.defaultValue,
+    'Enter the host name to use for the Hedera Explorer TLS: ',
+    null,
+    flags.hederaExplorerTlsHostName.name)
 }
 
 export async function promptOperatorId (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: flags.operatorId.definition.defaultValue,
-        message: 'Enter operator ID: '
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.operatorId.name}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    flags.operatorId.definition.defaultValue,
+    'Enter operator ID: ',
+    null,
+    flags.operatorId.name)
 }
 
 export async function promptOperatorKey (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: flags.operatorKey.definition.defaultValue,
-        message: 'Enter operator ID: '
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.operatorKey.name}`, e)
-  }
+  return await promptText(
+    task,
+    input,
+    flags.operatorKey.definition.defaultValue,
+    'Enter operator private key: ',
+    null,
+    flags.operatorKey.name)
 }
 
 export async function promptReplicaCount (task, input) {
@@ -420,51 +317,33 @@ export async function promptReplicaCount (task, input) {
 }
 
 export async function promptGenerateGossipKeys (task, input) {
-  try {
-    if (typeof input !== 'boolean') {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.generateGossipKeys.definition.defaultValue,
-        message: `Would you like to generate Gossip keys? ${typeof input} ${input}`
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deletePvcs.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.generateGossipKeys.definition.defaultValue,
+    `Would you like to generate Gossip keys? ${typeof input} ${input} `,
+    null,
+    flags.generateGossipKeys.name)
 }
 
 export async function promptGenerateTLSKeys (task, input) {
-  try {
-    if (typeof input !== 'boolean') {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.generateTlsKeys.definition.defaultValue,
-        message: 'Would you like to generate TLS keys?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deletePvcs.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.generateTlsKeys.definition.defaultValue,
+    'Would you like to generate TLS keys? ',
+    null,
+    flags.generateTlsKeys.name)
 }
 
 export async function promptDeletePvcs (task, input) {
-  try {
-    if (input === undefined) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'toggle',
-        default: flags.deletePvcs.definition.defaultValue,
-        message: 'Would you like to delete persistent volume claims upon uninstall?'
-      })
-    }
-
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.deployCertManagerCRDs.name}`, e)
-  }
+  return await promptToggle(
+    task,
+    input,
+    flags.deletePvcs.definition.defaultValue,
+    'Would you like to delete persistent volume claims upon uninstall? ',
+    null,
+    flags.deletePvcs.name)
 }
 
 export async function promptKeyFormat (task, input, choices = [constants.KEY_FORMAT_PFX, constants.KEY_FORMAT_PEM]) {
@@ -492,19 +371,23 @@ export async function promptKeyFormat (task, input, choices = [constants.KEY_FOR
 }
 
 export async function promptFstChartVersion (task, input) {
-  try {
-    if (!input) {
-      input = await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'text',
-        default: flags.fstChartVersion.definition.defaultValue,
-        message: 'Enter fullstack testing chart version: '
-      })
-    }
+  return await promptText(
+    task,
+    input,
+    flags.fstChartVersion.definition.defaultValue,
+    'Enter fullstack testing chart version: ',
+    null,
+    flags.fstChartVersion.name)
+}
 
-    return input
-  } catch (e) {
-    throw new FullstackTestingError(`input failed: ${flags.fstChartVersion.name}`, e)
-  }
+export async function promptUpdateAccountKeys (task, input) {
+  return await promptToggle(
+    task,
+    input,
+    flags.updateAccountKeys.definition.defaultValue,
+    'Would you like to updates the special account keys to new keys and stores their keys in a corresponding Kubernetes secret? ',
+    null,
+    flags.updateAccountKeys.name)
 }
 
 export function getPromptMap () {
@@ -537,6 +420,7 @@ export function getPromptMap () {
     .set(flags.deletePvcs.name, promptDeletePvcs)
     .set(flags.keyFormat.name, promptKeyFormat)
     .set(flags.fstChartVersion.name, promptFstChartVersion)
+    .set(flags.updateAccountKeys.name, promptUpdateAccountKeys)
 }
 
 // build the prompt registry

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -107,6 +107,7 @@ export class AccountManager {
           accountIdNum++
         }
       } else {
+        // TODO test GKE account update
         // TODO need to use the account keys from the node metadata
         for (const serviceObject of serviceMap.values()) {
           if (!serviceObject.loadBalancerIp) {
@@ -175,6 +176,7 @@ export class AccountManager {
       }
     }
     await Promise.allSettled(accountUpdatePromiseArray).then((results) => {
+      // TODO write a better summary here, and use info messages (fulfilled counts, rejects, skips, etc.)
       for (const result of results) {
         if (result.status === 'rejected') {
           this.logger.error(`accountId failed to update the account ID and create its secret: ${result.value}`)

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -52,9 +52,9 @@ export class AccountManager {
     this.portForwards = []
   }
 
-  // TODO what needs to move into k8.mjs?
-
+  // TODO add jsdoc
   async prepareAccount (namespace) {
+    // TODO add disable account key update flag to node start commands
     const serviceMap = await this.getNodeServiceMap(namespace)
 
     const nodeClient = await this.getNodeClient(namespace, serviceMap)
@@ -107,7 +107,6 @@ export class AccountManager {
           accountIdNum++
         }
       } else {
-        // TODO test GKE account update
         // TODO need to use the account keys from the node metadata
         for (const serviceObject of serviceMap.values()) {
           if (!serviceObject.loadBalancerIp) {
@@ -138,6 +137,7 @@ export class AccountManager {
    */
   async getNodeServiceMap (namespace) {
     const labelSelector = 'fullstack.hedera.com/node-name,fullstack.hedera.com/type=haproxy-svc'
+    // TODO move to K8
     const serviceList = await this.k8.kubeClient.listNamespacedService(
       namespace, undefined, undefined, undefined, undefined, labelSelector)
     const serviceMap = new Map()

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -60,12 +60,12 @@ export class AccountManager {
     const serviceMap = await this.getNodeServiceMap(namespace)
 
     const nodeClient = await this.getNodeClient(namespace, serviceMap)
-    nodeClient.setOperator(constants.OPERATOR_ID, constants.OPERATOR_KEY)
-    // nodeClient.setTransportSecurity(true)
 
-    await this.updateSpecialAccountsKeys(namespace, nodeClient, constants.SYSTEM_ACCOUNTS)
+    // TODO update before PR merge
+    // await this.updateSpecialAccountsKeys(namespace, nodeClient, constants.SYSTEM_ACCOUNTS)
     // update the treasury 0.0.2 account last
-    await this.updateSpecialAccountsKeys(namespace, nodeClient, [[2, 2]])
+    // await this.updateSpecialAccountsKeys(namespace, nodeClient, [[2, 2]])
+    await this.updateSpecialAccountsKeys(namespace, nodeClient, [[4, 4]])
     nodeClient.close()
     await this.stopPortForwards()
   }
@@ -143,8 +143,14 @@ export class AccountManager {
       }
 
       this.logger.debug(`creating client from network configuration: ${JSON.stringify(nodes)}`)
-
-      return Client.fromConfig({ network: nodes })
+      const nodeClient = Client.fromConfig({ network: nodes })
+      nodeClient.setOperator(constants.OPERATOR_ID, constants.OPERATOR_KEY)
+      if (this.isLocalhost()) {
+        // const nodeAddressBook = new NodeAddressBook()
+        // nodeClient.setNetworkFromAddressBook(nodeAddressBook)
+        nodeClient.setTransportSecurity(true)
+      }
+      return nodeClient
     } catch (e) {
       throw new FullstackTestingError('failed to setup node client', e)
     }

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -1,0 +1,7 @@
+export class AccountManager {
+  constructor (logger) {
+    if (!logger) throw new Error('An instance of core/Logger is required')
+
+    this.logger = logger
+  }
+}

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 export class AccountManager {
   constructor (logger, k8) {
     if (!logger) throw new Error('An instance of core/Logger is required')
@@ -13,9 +29,9 @@ export class AccountManager {
 
   async jeromyTesting (argv) {
     const { namespace, nodeIds } = argv
-    const labelSelector =
+    const labelSelector = ''
     const serviceList = await this.k8.kubeClient.listNamespacedService(
-        namespace, undefined, undefined, undefined, undefined, labelSelector)
+      namespace, undefined, undefined, undefined, undefined, labelSelector)
     // const clusterInfo = this.kubeClient.getCurrentCluster()
     const componentStatus = await this.k8.kubeClient.listComponentStatus()
     return {

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -14,17 +14,120 @@
  * limitations under the License.
  *
  */
+import * as constants from './constants.mjs'
+import {
+  AccountInfoQuery, AccountUpdateTransaction,
+  Client,
+  KeyList,
+  PrivateKey
+} from '@hashgraph/sdk'
+import { FullstackTestingError } from './errors.mjs'
+import { sleep } from './helpers.mjs'
+import net from 'net'
+import { LOCAL_NODE_START_PORT } from './constants.mjs'
+
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 export class AccountManager {
-  constructor (logger, k8) {
+  constructor (logger, k8, constants) {
     if (!logger) throw new Error('An instance of core/Logger is required')
     if (!k8) throw new Error('An instance of core/K8 is required')
 
     this.logger = logger
     this.k8 = k8
+    this.portForwards = []
   }
 
-  async prepareAccount () {
+  // TODO what needs to move into k8.mjs?
 
+  async prepareAccount (namespace) {
+    const serviceMap = await this.getNodeServiceMap(namespace)
+
+    const nodeClient = await this.getNodeClient(namespace, serviceMap)
+    nodeClient.setOperator(constants.OPERATOR_ID, constants.OPERATOR_KEY)
+
+    await this.updateSpecialAccountsKeys(namespace, nodeClient, constants.SYSTEM_ACCOUNTS)
+    // update the treasury 0.0.2 account last
+    await this.updateSpecialAccountsKeys(namespace, nodeClient, [[2, 2]])
+    nodeClient.close()
+    await this.stopPortForwards()
+  }
+
+  async stopPortForwards () {
+    this.portForwards.forEach(server => {
+      server.close()
+    })
+    this.portForwards = []
+  }
+
+  async getNodeClient (namespace, serviceMap) {
+    const nodes = {}
+    try {
+      let localPort = LOCAL_NODE_START_PORT
+      let accountIdNum = parseInt(constants.HEDERA_NODE_ACCOUNT_ID_START.num.toString(), 10)
+      if (this.isLocalhost()) {
+        for (const serviceObject of serviceMap.values()) {
+          this.portForwards.push(await this.k8.portForward(serviceObject.podName, localPort, serviceObject.grpcPort))
+
+          nodes[`127.0.0.1:${localPort}`] = `${constants.HEDERA_NODE_ACCOUNT_ID_START.realm}.${constants.HEDERA_NODE_ACCOUNT_ID_START.shard}.${accountIdNum}`
+          // check if the port is actually accessible
+          let attempt = 1
+          let socket = null
+          while (attempt < 10) {
+            try {
+              await sleep(250)
+              this.logger.debug(`Checking exposed port '${localPort}' of pod ${serviceObject.podName}`)
+              socket = net.createConnection({ port: localPort })
+              this.logger.debug(`Connected to exposed port '${localPort}' of pod ${serviceObject.podName}`)
+              break
+            } catch (e) {
+              attempt += 1
+            }
+          }
+          if (!socket) {
+            throw new FullstackTestingError(`failed to expose port '${serviceObject.grpcPort}' of pod '${serviceObject.podName}'`)
+          }
+
+          socket.destroy()
+          localPort++
+          accountIdNum++
+        }
+      } else {
+        // TODO need to use the account keys from the node metadata
+        for (const serviceObject of serviceMap.values()) {
+          if (!serviceObject.loadBalancerIp) {
+            throw new Error(
+                `Expected service ${serviceObject.name} to have a loadBalancerIP set for basepath ${this.k8.kubeClient.basePath}`)
+          }
+
+          nodes[`${serviceObject.loadBalancerIp}:${serviceObject.grpcPort}`] = `${constants.HEDERA_NODE_ACCOUNT_ID_START.realm}.${constants.HEDERA_NODE_ACCOUNT_ID_START.shard}.${accountIdNum}`
+          accountIdNum++
+        }
+      }
+      // TODO test Client.setTransportSecurity(true) with grpcs
+      this.logger.debug(`creating client from network configuration: ${JSON.stringify(nodes)}`)
+      return Client.fromConfig({ network: nodes })
+    } catch (e) {
+      throw new FullstackTestingError('failed to setup node client', e)
+    }
+  }
+
+  isLocalhost () {
+    return this.k8.kubeClient.basePath.includes('127.0.0.1')
   }
 
   /**
@@ -43,8 +146,8 @@ export class AccountManager {
       const serviceObject = {}
       serviceObject.name = service.metadata.name
       serviceObject.loadBalancerIp = service.status.loadBalancer.ingress ? service.status.loadBalancer.ingress[0].ip : undefined
-      serviceObject.grpcPort = service.spec.ports.filter(port => port.name === 'non-tls-grpc-client-port')[0].nodePort
-      serviceObject.grpcsPort = service.spec.ports.filter(port => port.name === 'tls-grpc-client-port')[0].nodePort
+      serviceObject.grpcPort = service.spec.ports.filter(port => port.name === 'non-tls-grpc-client-port')[0].port
+      serviceObject.grpcsPort = service.spec.ports.filter(port => port.name === 'tls-grpc-client-port')[0].port
       serviceObject.node = service.metadata.labels['fullstack.hedera.com/node-name']
       serviceObject.selector = service.spec.selector.app
       serviceMap.set(serviceObject.node, serviceObject)
@@ -59,6 +162,113 @@ export class AccountManager {
     }
 
     return serviceMap
+  }
+
+  async updateSpecialAccountsKeys (namespace, nodeClient, accounts) {
+    const genesisKey = PrivateKey.fromStringED25519(constants.OPERATOR_KEY)
+    const accountUpdatePromiseArray = []
+
+    for (const [start, end] of accounts) {
+      for (let i = start; i <= end; i++) {
+        accountUpdatePromiseArray.push(this.updateAccountKeys(
+          namespace, nodeClient, `${constants.HEDERA_NODE_ACCOUNT_ID_START.realm}.${constants.HEDERA_NODE_ACCOUNT_ID_START.shard}.${i}`, genesisKey))
+      }
+    }
+    await Promise.allSettled(accountUpdatePromiseArray).then((results) => {
+      for (const result of results) {
+        if (result.status === 'rejected') {
+          this.logger.error(`accountId failed to update the account ID and create its secret: ${result.value}`)
+        }
+      }
+    })
+  }
+
+  async updateAccountKeys (namespace, nodeClient, accountId, genesisKey) {
+    try {
+      const keys = await this.getAccountKeys(accountId, nodeClient)
+      this.logger.debug(`retrieved keys for account ${accountId}`)
+
+      if (constants.OPERATOR_PUBLIC_KEY !== keys[0].toString()) {
+        this.logger.debug(`account ${accountId} can be skipped since it does not have a genesis key`)
+        return {
+          status: 'skipped',
+          value: accountId
+        }
+      }
+
+      const newPrivateKey = PrivateKey.generateED25519()
+      await this.sendAccountKeyUpdate(accountId, newPrivateKey, nodeClient, genesisKey)
+      this.logger.debug(`sent account key update for account ${accountId}`)
+
+      const data = {
+        privateKey: newPrivateKey.toString(),
+        publicKey: newPrivateKey.publicKey.toString()
+      }
+
+      if (!(await this.k8.createSecret(`account-key-${accountId}`, namespace, 'Opaque', data))) {
+        this.logger.error(`failed to create secret for accountId ${accountId}`)
+        return {
+          status: 'rejected',
+          value: accountId
+        }
+      }
+      this.logger.debug(`created k8s secret for account ${accountId}`)
+
+      return {
+        status: 'fulfilled',
+        value: accountId
+      }
+    } catch (e) {
+      console.log(`account: ${accountId}, had an error: ${e.toString()}`)
+      return {
+        status: 'rejected',
+        value: accountId
+      }
+    }
+  }
+
+  async getAccountKeys (accountId, nodeClient) {
+    const accountInfo = await new AccountInfoQuery()
+      .setAccountId(accountId)
+      .execute(nodeClient)
+
+    let keys
+    if (accountInfo.key instanceof KeyList) {
+      keys = accountInfo.key.toArray()
+    } else {
+      keys = []
+      keys.push(accountInfo.key)
+    }
+
+    return keys
+  }
+
+  async sendAccountKeyUpdate (accountId, newPrivateKey, nodeClient, genesisKey) {
+    this.logger.debug(
+        `Updating account ${accountId} with new public and private keys`)
+
+    // Create the transaction to update the key on the account
+    const transaction = await new AccountUpdateTransaction()
+      .setAccountId(accountId)
+      .setKey(newPrivateKey.publicKey)
+      .freezeWith(nodeClient)
+
+    // Sign the transaction with the old key and new key
+    const signTx = await (await transaction.sign(genesisKey)).sign(
+      newPrivateKey)
+
+    // SIgn the transaction with the client operator private key and submit to a Hedera network
+    const txResponse = await signTx.execute(nodeClient)
+
+    // Request the receipt of the transaction
+    const receipt = await txResponse.getReceipt(nodeClient)
+
+    // Get the transaction consensus status
+    const transactionStatus = receipt.status
+
+    this.logger.debug(
+        `The transaction consensus status for update of accountId ${accountId} is ${transactionStatus.toString()}`)
+    // TODO check status is correct before continuing
   }
 
   async jeromyTesting (argv) {

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -1,7 +1,29 @@
 export class AccountManager {
-  constructor (logger) {
+  constructor (logger, k8) {
     if (!logger) throw new Error('An instance of core/Logger is required')
+    if (!k8) throw new Error('An instance of core/K8 is required')
 
     this.logger = logger
+    this.k8 = k8
+  }
+
+  async prepareAccount () {
+
+  }
+
+  async jeromyTesting (argv) {
+    const { namespace, nodeIds } = argv
+    const labelSelector =
+    const serviceList = await this.k8.kubeClient.listNamespacedService(
+        namespace, undefined, undefined, undefined, undefined, labelSelector)
+    // const clusterInfo = this.kubeClient.getCurrentCluster()
+    const componentStatus = await this.k8.kubeClient.listComponentStatus()
+    return {
+      serviceList,
+      // "clusterInfo": clusterInfo,
+      componentStatus,
+      kubeClient: this.k8.kubeClient,
+      basePath: this.k8.kubeClient.basePath
+    }
   }
 }

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -173,6 +173,8 @@ export class AccountManager {
       for (let i = start; i <= end; i++) {
         accountUpdatePromiseArray.push(this.updateAccountKeys(
           namespace, nodeClient, `${constants.HEDERA_NODE_ACCOUNT_ID_START.realm}.${constants.HEDERA_NODE_ACCOUNT_ID_START.shard}.${i}`, genesisKey))
+        // TODO make this a flag that can be passed in, or a constant / environment variable
+        await sleep(5) // sleep a little to prevent overwhelming the servers
       }
     }
     await Promise.allSettled(accountUpdatePromiseArray).then((results) => {

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -71,6 +71,7 @@ export class AccountManager {
       return null
     }
   }
+  // TODO remember to retest GKE once all of the e2e test cases are passing
 
   // TODO why does it prompt me for the chart directory during cluster setup even though I specified during init?
   // TODO add jsdoc

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -31,7 +31,7 @@ import { Templates } from './templates.mjs'
 const REASON_FAILED_TO_GET_KEYS = 'failed to get keys for accountId'
 const REASON_SKIPPED = 'skipped since it does not have a genesis key'
 const REASON_FAILED_TO_UPDATE_ACCOUNT = 'failed to update account keys'
-const REASON_FAILED_TO_CREATE_SECRET = 'failed to create secret'
+const REASON_FAILED_TO_CREATE_K8S_S_KEY = 'failed to create k8s scrt key'
 
 /**
  * Copyright (C) 2024 Hedera Hashgraph, LLC
@@ -251,7 +251,7 @@ export class AccountManager {
         this.logger.error(`failed to create secret for accountId ${accountId.toString()}`)
         return {
           status: 'rejected',
-          reason: REASON_FAILED_TO_CREATE_SECRET,
+          reason: REASON_FAILED_TO_CREATE_K8S_S_KEY,
           value: accountId.toString()
         }
       }
@@ -260,7 +260,7 @@ export class AccountManager {
       this.logger.error(`failed to create secret for accountId ${accountId.toString()}, e: ${e.toString()}`)
       return {
         status: 'rejected',
-        reason: REASON_FAILED_TO_CREATE_SECRET,
+        reason: REASON_FAILED_TO_CREATE_K8S_S_KEY,
         value: accountId.toString()
       }
     }

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -90,7 +90,6 @@ export class AccountManager {
    * @returns {Promise<void>}
    */
   async prepareAccounts (namespace) {
-    // TODO add disable account key update flag to node start commands or future GH Issue?
     const serviceMap = await this.getNodeServiceMap(namespace)
 
     const nodeClient = await this.getNodeClient(
@@ -137,7 +136,7 @@ export class AccountManager {
               `Expected service ${serviceObject.name} to have a loadBalancerIP set for basepath ${this.k8.kubeClient.basePath}`)
         }
         const host = this.isLocalhost() ? '127.0.0.1' : serviceObject.loadBalancerIp
-        const port = serviceObject.grpcPort // TODO add grpcs logic
+        const port = serviceObject.grpcPort // TODO: add grpcs logic in https://github.com/hashgraph/full-stack-testing/issues/752
         const targetPort = this.isLocalhost() ? localPort : port
 
         if (this.isLocalhost()) {

--- a/solo/src/core/account_manager.mjs
+++ b/solo/src/core/account_manager.mjs
@@ -96,6 +96,7 @@ export class AccountManager {
         server.close()
       })
       this.portForwards = []
+      await sleep(1) // give a tick for connections to close
     }
   }
 
@@ -361,5 +362,6 @@ export class AccountManager {
       throw new FullstackTestingError(`failed to connect to port '${port}' of pod ${podName} at IP address ${host}`)
     }
     socket.destroy()
+    await sleep(1) // gives a few ticks for connections to close
   }
 }

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -76,7 +76,7 @@ export const DEFAULT_CHART_REPO = new Map()
 export const OPERATOR_ID = process.env.SOLO_OPERATOR_ID || '0.0.2'
 export const OPERATOR_KEY = process.env.SOLO_OPERATOR_KEY || '302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137'
 export const OPERATOR_PUBLIC_KEY = process.env.SOLO_OPERATOR_PUBLIC_KEY || '302a300506032b65700321000aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92'
-export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000], [2, 2]]
+export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -78,6 +78,7 @@ export const OPERATOR_KEY = process.env.SOLO_OPERATOR_KEY || '302e02010030050603
 export const OPERATOR_PUBLIC_KEY = process.env.SOLO_OPERATOR_PUBLIC_KEY || '302a300506032b65700321000aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92'
 export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
 export const LOCAL_NODE_START_PORT = process.env.LOCAL_NODE_START_PORT || 30212
+export const ACCOUNT_KEYS_UPDATE_PAUSE = process.env.ACCOUNT_KEYS_UPDATE_PAUSE || 5
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -77,6 +77,7 @@ export const OPERATOR_ID = process.env.SOLO_OPERATOR_ID || '0.0.2'
 export const OPERATOR_KEY = process.env.SOLO_OPERATOR_KEY || '302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137'
 export const OPERATOR_PUBLIC_KEY = process.env.SOLO_OPERATOR_PUBLIC_KEY || '302a300506032b65700321000aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92'
 export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
+export const LOCAL_NODE_START_PORT = process.env.LOCAL_NODE_START_PORT || 30212
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -79,7 +79,7 @@ export const OPERATOR_PUBLIC_KEY = process.env.SOLO_OPERATOR_PUBLIC_KEY || '302a
 export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
 export const TREASURY_ACCOUNT = [[2, 2]]
 export const LOCAL_NODE_START_PORT = process.env.LOCAL_NODE_START_PORT || 30212
-export const ACCOUNT_KEYS_UPDATE_PAUSE = process.env.ACCOUNT_KEYS_UPDATE_PAUSE || 3
+export const ACCOUNT_KEYS_UPDATE_PAUSE = process.env.ACCOUNT_KEYS_UPDATE_PAUSE || 5
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -75,6 +75,8 @@ export const DEFAULT_CHART_REPO = new Map()
 // ------------------- Hedera Account related ---------------------------------------------------------------------------------
 export const OPERATOR_ID = process.env.SOLO_OPERATOR_ID || '0.0.2'
 export const OPERATOR_KEY = process.env.SOLO_OPERATOR_KEY || '302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137'
+export const OPERATOR_PUBLIC_KEY = process.env.SOLO_OPERATOR_PUBLIC_KEY || '302a300506032b65700321000aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92'
+export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000], [2, 2]]
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/solo/src/core/constants.mjs
+++ b/solo/src/core/constants.mjs
@@ -77,8 +77,9 @@ export const OPERATOR_ID = process.env.SOLO_OPERATOR_ID || '0.0.2'
 export const OPERATOR_KEY = process.env.SOLO_OPERATOR_KEY || '302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137'
 export const OPERATOR_PUBLIC_KEY = process.env.SOLO_OPERATOR_PUBLIC_KEY || '302a300506032b65700321000aa8e21064c61eab86e2a9c164565b4e7a9a4146106e0a6cd03a8c395a110e92'
 export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
+export const TREASURY_ACCOUNT = [[2, 2]]
 export const LOCAL_NODE_START_PORT = process.env.LOCAL_NODE_START_PORT || 30212
-export const ACCOUNT_KEYS_UPDATE_PAUSE = process.env.ACCOUNT_KEYS_UPDATE_PAUSE || 5
+export const ACCOUNT_KEYS_UPDATE_PAUSE = process.env.ACCOUNT_KEYS_UPDATE_PAUSE || 3
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/solo/src/core/k8.mjs
+++ b/solo/src/core/k8.mjs
@@ -715,4 +715,18 @@ export class K8 {
       fs.rmSync(tmpFile)
     }
   }
+
+  async jeromyTesting (argv) {
+    const { namespace, nodeIds } = argv
+    const serviceList = await this.kubeClient.listNamespacedService(namespace)
+    // const clusterInfo = this.kubeClient.getCurrentCluster()
+    const componentStatus = await this.kubeClient.listComponentStatus()
+    return {
+      serviceList,
+      // "clusterInfo": clusterInfo,
+      componentStatus,
+      kubeClient: this.kubeClient,
+      basePath: this.kubeClient.basePath
+    }
+  }
 }

--- a/solo/src/core/k8.mjs
+++ b/solo/src/core/k8.mjs
@@ -715,18 +715,4 @@ export class K8 {
       fs.rmSync(tmpFile)
     }
   }
-
-  async jeromyTesting (argv) {
-    const { namespace, nodeIds } = argv
-    const serviceList = await this.kubeClient.listNamespacedService(namespace)
-    // const clusterInfo = this.kubeClient.getCurrentCluster()
-    const componentStatus = await this.kubeClient.listComponentStatus()
-    return {
-      serviceList,
-      // "clusterInfo": clusterInfo,
-      componentStatus,
-      kubeClient: this.kubeClient,
-      basePath: this.kubeClient.basePath
-    }
-  }
 }

--- a/solo/src/core/k8.mjs
+++ b/solo/src/core/k8.mjs
@@ -24,6 +24,7 @@ import { FullstackTestingError, MissingArgumentError } from './errors.mjs'
 import * as sb from 'stream-buffers'
 import * as tar from 'tar'
 import { v4 as uuid4 } from 'uuid'
+import { V1ObjectMeta, V1Secret } from '@kubernetes/client-node'
 
 /**
  * A kubernetes API wrapper class providing custom functionalities required by solo
@@ -684,6 +685,18 @@ export class K8 {
     )
 
     return resp.response.statusCode === 200.0
+  }
+
+  async createSecret (name, namespace, secretType, data) {
+    const v1Secret = new V1Secret()
+    v1Secret.apiVersion = 'v1'
+    v1Secret.kind = 'Secret'
+    v1Secret.metadata = new V1ObjectMeta()
+    v1Secret.metadata.name = name
+    v1Secret.type = secretType
+    v1Secret.data = data
+    const resp = await this.kubeClient.createNamespacedSecret(namespace, v1Secret)
+    return resp.response.statusCode === 201
   }
 
   _getNamespace () {

--- a/solo/src/core/k8.mjs
+++ b/solo/src/core/k8.mjs
@@ -687,6 +687,13 @@ export class K8 {
     return resp.response.statusCode === 200.0
   }
 
+  /**
+   * retrieve the secret of the given namespace and label selector, if there is more than one, it returns the first
+   * @param namespace the namespace of the secret to search for
+   * @param labelSelector the label selector used to fetch the Kubernetes secret
+   * @returns {Promise<null|{data: {[p: string]: string}, name: string, namespace: string, type: string, labels: {[p: string]: string}}>} a
+   * custom secret object with the relevant attributes
+   */
   async getSecret (namespace, labelSelector) {
     const result = await this.kubeClient.listNamespacedSecret(
       namespace, null, null, null, null, labelSelector)
@@ -704,6 +711,16 @@ export class K8 {
     }
   }
 
+  /**
+   * creates a new Kubernetes secret with the provided attributes
+   * @param name the name of the new secret
+   * @param namespace the namespace to store the secret
+   * @param secretType the secret type
+   * @param data the secret
+   * @param labels the label to use for future label selector queries
+   * @param recreate if we should first run delete in the case that there the secret exists from a previous install
+   * @returns {Promise<boolean>} whether the secret was created successfully
+   */
   async createSecret (name, namespace, secretType, data, labels, recreate) {
     if (recreate) {
       try {

--- a/solo/src/core/templates.mjs
+++ b/solo/src/core/templates.mjs
@@ -78,14 +78,29 @@ export class Templates {
     return `${parsed[0]}.${parsed[1]}`
   }
 
+  /**
+   * renders the name to be used to store the new account key as a Kubernetes secret
+   * @param accountId the account ID, string or AccountId type
+   * @returns {string} the name of the Kubernetes secret to store the account key
+   */
   static renderAccountKeySecretName (accountId) {
     return `account-key-${accountId.toString()}`
   }
 
+  /**
+   * renders the label selector to be used to fetch the new account key from the Kubernetes secret
+   * @param accountId the account ID, string or AccountId type
+   * @returns {string} the label selector of the Kubernetes secret to retrieve the account key   */
   static renderAccountKeySecretLabelSelector (accountId) {
     return `fullstack.hedera.com/account-id=${accountId.toString()}`
   }
 
+  /**
+   * renders the label object to be used to store the new account key in the Kubernetes secret
+   * @param accountId the account ID, string or AccountId type
+   * @returns {{"fullstack.hedera.com/account-id": string}} the label object to be used to
+   * store the new account key in the Kubernetes secret
+   */
   static renderAccountKeySecretLabelObject (accountId) {
     return {
       'fullstack.hedera.com/account-id': accountId.toString()

--- a/solo/src/core/templates.mjs
+++ b/solo/src/core/templates.mjs
@@ -78,6 +78,20 @@ export class Templates {
     return `${parsed[0]}.${parsed[1]}`
   }
 
+  static renderAccountKeySecretName (accountId) {
+    return `account-key-${accountId.toString()}`
+  }
+
+  static renderAccountKeySecretLabelSelector (accountId) {
+    return `fullstack.hedera.com/account-id=${accountId.toString()}`
+  }
+
+  static renderAccountKeySecretLabelObject (accountId) {
+    return {
+      'fullstack.hedera.com/account-id': accountId.toString()
+    }
+  }
+
   static renderDistinguishedName (nodeId,
     state = 'TX',
     locality = 'Richardson',

--- a/solo/src/index.mjs
+++ b/solo/src/index.mjs
@@ -31,6 +31,7 @@ import {
 } from './core/index.mjs'
 import 'dotenv/config'
 import { K8 } from './core/k8.mjs'
+import {AccountManager} from "./core/account_manager.mjs";
 
 export function main (argv) {
   const logger = logging.NewLogger('debug')
@@ -44,6 +45,7 @@ export function main (argv) {
     const k8 = new K8(configManager, logger)
     const platformInstaller = new PlatformInstaller(logger, k8)
     const keyManager = new KeyManager(logger)
+    const accountManager = new AccountManager(logger)
 
     // set cluster and namespace in the global configManager from kubernetes context
     // so that we don't need to prompt the user
@@ -60,7 +62,8 @@ export function main (argv) {
       chartManager,
       configManager,
       depManager,
-      keyManager
+      keyManager,
+      accountManager
     }
 
     const processArguments = (argv, yargs) => {

--- a/solo/src/index.mjs
+++ b/solo/src/index.mjs
@@ -31,7 +31,7 @@ import {
 } from './core/index.mjs'
 import 'dotenv/config'
 import { K8 } from './core/k8.mjs'
-import {AccountManager} from "./core/account_manager.mjs";
+import { AccountManager } from './core/account_manager.mjs'
 
 export function main (argv) {
   const logger = logging.NewLogger('debug')
@@ -45,7 +45,7 @@ export function main (argv) {
     const k8 = new K8(configManager, logger)
     const platformInstaller = new PlatformInstaller(logger, k8)
     const keyManager = new KeyManager(logger)
-    const accountManager = new AccountManager(logger)
+    const accountManager = new AccountManager(logger, k8)
 
     // set cluster and namespace in the global configManager from kubernetes context
     // so that we don't need to prompt the user

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -234,9 +234,9 @@ describe.each([
           new LocalProvider({ client })
         )
 
-        // for (const [start, end] of constants.SYSTEM_ACCOUNTS) {
-        for (const [start, end] of [[3, 3]]) {
+        for (const [start, end] of constants.SYSTEM_ACCOUNTS) {
           for (let i = start; i <= end; i++) {
+
             const accountId = `0.0.${i}`
 
             let keys = await TestHelper.getAccountKeys(accountId, wallet)
@@ -270,7 +270,13 @@ describe.each([
 
             expect(keys[0].toString()).not.toEqual(constants.OPERATOR_PUBLIC_KEY)
 
-
+            const data = {
+              privateKey: newPrivateKey.toString(),
+              publicKey: newPrivateKey.publicKey.toString()
+            }
+            const response = await k8.createSecret(`account-key-${accountId}`, argv[namespace], 'Opaque', data)
+            console.log(JSON.stringify(response))
+            expect(response).toBeTruthy()
           }
         }
       } catch (e) {
@@ -281,7 +287,7 @@ describe.each([
       if (client) {
         client.close()
       }
-    }, 90000)
+    }, 900000)
 
     it('balance query should succeed', async () => {
       expect.assertions(1)

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -109,6 +109,7 @@ class TestHelper {
   }
 
   static getAccountKeys = async function (accountId, wallet) {
+    // TODO update to get secret from k8s
     console.log(`Get key for account ${accountId}`)
     const accountInfo = await new AccountInfoQuery()
       .setAccountId(accountId)
@@ -223,6 +224,7 @@ describe.each([
     }, 60000)
 
     it('only genesis account should have genesis key', async () => {
+      // TODO update only check keys are not equal
       expect.hasAssertions()
       let client = null
       const genesisKey = PrivateKey.fromStringED25519(constants.OPERATOR_KEY)

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -105,8 +105,9 @@ describe.each([
     argv[flags.settingTxt.name] = flags.settingTxt.definition.defaultValue
     argv[flags.log4j2Xml.name] = flags.log4j2Xml.definition.defaultValue
     argv[flags.namespace.name] = 'solo-e2e'
-    argv[flags.clusterName] = 'kind-solo-e2e'
-    argv[flags.clusterSetupNamespace] = 'solo-e2e-cluster'
+    argv[flags.clusterName.name] = 'kind-solo-e2e'
+    argv[flags.clusterSetupNamespace.name] = 'solo-e2e-cluster'
+    argv[flags.updateAccountKeys.name] = true
     configManager.update(argv, true)
 
     const nodeIds = argv[flags.nodeIDs.name].split(',')

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -43,6 +43,7 @@ import {
 } from '../../../src/core/index.mjs'
 import { ShellRunner } from '../../../src/core/shell_runner.mjs'
 import { getTestCacheDir, testLogger } from '../../test_util.js'
+import { AccountManager } from '../../../src/core/account_manager.mjs'
 
 class TestHelper {
   static portForwards = []
@@ -138,6 +139,7 @@ describe.each([
   const k8 = new K8(configManager, testLogger)
   const platformInstaller = new PlatformInstaller(testLogger, k8)
   const keyManager = new KeyManager(testLogger)
+  const accountManager = new AccountManager(testLogger, k8, constants)
 
   const nodeCmd = new NodeCommand({
     logger: testLogger,
@@ -148,7 +150,8 @@ describe.each([
     downloader: packageDownloader,
     platformInstaller,
     depManager,
-    keyManager
+    keyManager,
+    accountManager
   })
 
   const cacheDir = getTestCacheDir()
@@ -236,7 +239,7 @@ describe.each([
 
         const accountUpdatePromiseArray = []
         // for (const [start, end] of constants.SYSTEM_ACCOUNTS) {
-        for (const [start, end] of [[3, 6]]) {
+        for (const [start, end] of [[3, 3]]) {
           for (let i = start; i <= end; i++) {
             accountUpdatePromiseArray.push((async function (i) {
               const accountId = `0.0.${i}`

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -130,7 +130,7 @@ describe.each([
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
       }
-    }, 300000)
+    }, 600000)
 
     it('only genesis account should have genesis key', async () => {
       expect.hasAssertions()

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -65,7 +65,7 @@ describe.each([
 ])('NodeCommand', (testRelease, testKeyFormat) => {
   const helm = new Helm(testLogger)
   const chartManager = new ChartManager(helm, testLogger)
-  const configManager = new ConfigManager(testLogger)
+  const configManager = new ConfigManager(testLogger, path.join(getTestCacheDir(), 'solo.config'))
   const packageDownloader = new PackageDownloader(testLogger)
   const depManager = new DependencyManager(testLogger)
   const k8 = new K8(configManager, testLogger)
@@ -104,8 +104,10 @@ describe.each([
     argv[flags.bootstrapProperties.name] = flags.bootstrapProperties.definition.defaultValue
     argv[flags.settingTxt.name] = flags.settingTxt.definition.defaultValue
     argv[flags.log4j2Xml.name] = flags.log4j2Xml.definition.defaultValue
-    configManager.load()
-    argv[flags.namespace.name] = configManager.getFlag(flags.namespace)
+    argv[flags.namespace.name] = 'solo-e2e'
+    argv[flags.clusterName] = 'kind-solo-e2e'
+    argv[flags.clusterSetupNamespace] = 'solo-e2e-cluster'
+    configManager.update(argv, true)
 
     const nodeIds = argv[flags.nodeIDs.name].split(',')
 

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -20,7 +20,7 @@ import {
   Hbar,
   PrivateKey
 } from '@hashgraph/sdk'
-import { afterEach, beforeAll, describe, expect, it } from '@jest/globals'
+import { beforeAll, describe, expect, it } from '@jest/globals'
 import path from 'path'
 import { namespace } from '../../../src/commands/flags.mjs'
 import { flags } from '../../../src/commands/index.mjs'
@@ -82,10 +82,6 @@ describe.each([
 
   const cacheDir = getTestCacheDir()
 
-  afterEach(() => {
-    accountManager.stopPortForwards().then().catch()
-  })
-
   describe(`node start should succeed [release ${testRelease}, keyFormat: ${testKeyFormat}]`, () => {
     const argv = {}
     argv[flags.releaseTag.name] = testRelease
@@ -134,20 +130,7 @@ describe.each([
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
       }
-    }, 120000)
-
-    it('nodes should be in ACTIVE status', async () => {
-      for (const nodeId of nodeIds) {
-        try {
-          await expect(nodeCmd.checkNetworkNodeStarted(nodeId, 5)).resolves.toBeTruthy()
-        } catch (e) {
-          testLogger.showUserError(e)
-          expect(e).toBeNull()
-        }
-
-        await nodeCmd.run(`tail ${constants.SOLO_LOGS_DIR}/solo.log`)
-      }
-    }, 60000)
+    }, 300000)
 
     it('only genesis account should have genesis key', async () => {
       expect.hasAssertions()
@@ -181,6 +164,7 @@ describe.each([
       } finally {
         if (client) {
           client.close()
+          accountManager.stopPortForwards().then().catch()
         }
       }
     }, 60000)
@@ -204,6 +188,7 @@ describe.each([
         if (client) {
           client.close()
         }
+        accountManager.stopPortForwards().then().catch()
       }
     }, 20000)
 
@@ -233,6 +218,7 @@ describe.each([
         if (client) {
           client.close()
         }
+        accountManager.stopPortForwards().then().catch()
       }
     }, 20000)
   })


### PR DESCRIPTION
## Description

This pull request changes the following:

- rekey special accounts at startup so they are not using genesis keys
- update haproxy.cfg to show more sysout to k8s logs
- added account-id labels to:
  - `charts/fullstack-deployment/templates/network-node-statefulset.yaml`
  - `charts/fullstack-deployment/templates/services/haproxy-svc.yaml`
- added sleep and check in `solo/src/commands/node.mjs.`.`checkNetworkNodePod` to support user calling the `solo node start` after it was previously already running
- refactored prompts.mjs to reduce duplication
- added new methods to `solo/src/core/k8.mjs`
  - `getSecret()`
  - `createSecret()`

### Related Issues

- Closes #668
