### PR TITLE
fix(chart): disable backup-uploader

### DIFF
--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -149,7 +149,7 @@ defaults:
           prioritize: true
       resources: {}
     backupUploader:
-      enabled: true
+      enabled: false
       nameOverride: "backup-uploader"
       image:
         registry: "gcr.io"


### PR DESCRIPTION
## Description

This pull request changes the following:

- `backup-uploader` is buggy as outline here: https://github.com/hashgraph/full-stack-testing/issues/745
- moreover, `backup-uploader` image is available only for amd64. As a result user is unable to deploy the chart in `microk8s cluster` or `aarch64 linux vm`

We shall enable it later once the correct image is available as tracked here: https://github.com/hashgraph/full-stack-testing/issues/747

### Related Issues

- Closes #
