### PR TITLE
fix(cli): assign node account ID correctly base on start account ID

### DIFF
--- a/solo/src/commands/network.mjs
+++ b/solo/src/commands/network.mjs
@@ -90,10 +90,12 @@ export class NetworkCommand extends BaseCommand {
     }
 
     // prepare name and account IDs for nodes
+    const realm = constants.HEDERA_NODE_ACCOUNT_ID_START.realm
+    const shard = constants.HEDERA_NODE_ACCOUNT_ID_START.shard
+    let accountId = constants.HEDERA_NODE_ACCOUNT_ID_START.num
     let i = 0
-    let accountId = Number.parseInt(constants.HEDERA_NODE_ACCOUNT_ID_START)
     config.nodeIds.forEach(nodeId => {
-      valuesArg += ` --set hedera.nodes[${i}].name=${nodeId},hedera.nodes[${i++}].accountId=0.0.${accountId++}`
+      valuesArg += ` --set hedera.nodes[${i}].name=${nodeId},hedera.nodes[${i++}].accountId=${realm}.${shard}.${accountId++}`
     })
 
     this.logger.debug('Prepared helm chart values', { valuesArg })

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -66,7 +66,7 @@ class TestHelper {
       const grpcPort = constants.HEDERA_NODE_GRPC_PORT.toString()
       const network = {}
 
-      let accountIdNum = parseInt(constants.HEDERA_NODE_ACCOUNT_ID_START.num.toString(), 10)
+      let accountIdNum = constants.HEDERA_NODE_ACCOUNT_ID_START.num
       for (let nodeId of nodeIds) {
         nodeId = nodeId.trim()
         const podName = Templates.renderNetworkPodName(nodeId)

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -243,6 +243,7 @@ describe.each([
         )
 
         let transaction = await new AccountCreateTransaction()
+          .setNodeAccountIds([constants.HEDERA_NODE_ACCOUNT_ID_START])
           .setInitialBalance(new Hbar(0))
           .setKey(accountKey.publicKey)
           .freezeWithSigner(wallet)


### PR DESCRIPTION
## Description

This pull request changes the following:

- assign node account ID correctly base on start account ID

### Related Issues

- Closes #748 
