### PR TITLE
fix(cli): refactor config manager with each function having a single responsibility to avoid confusion

### DIFF
--- a/solo/src/commands/flags.mjs
+++ b/solo/src/commands/flags.mjs
@@ -426,3 +426,5 @@ export const nodeConfigFileFlags = new Map([
   settingTxt,
   log4j2Xml
 ].map(f => [f.name, f]))
+
+export const integerFlags = new Map([replicaCount].map(f => [f.name, f]))

--- a/solo/src/core/config_manager.mjs
+++ b/solo/src/core/config_manager.mjs
@@ -22,142 +22,157 @@ import * as flags from '../commands/flags.mjs'
 import * as paths from 'path'
 import * as helpers from './helpers.mjs'
 
+/**
+ * ConfigManager cache command flag values so that user doesn't need to enter the same values repeatedly.
+ *
+ * For example, 'namespace' is usually remains the same across commands once it is entered, and therefore user
+ * doesn't need to enter it repeatedly. However, user should still be able to specify the flag explicitly for any command.
+ */
 export class ConfigManager {
-  constructor (logger, fstConfigFile = constants.SOLO_CONFIG_FILE, persistMode = true) {
+  constructor (logger, cachedConfigFile = constants.SOLO_CONFIG_FILE) {
     if (!logger || !(logger instanceof Logger)) throw new MissingArgumentError('An instance of core/Logger is required')
-
-    if (fstConfigFile === constants.SOLO_CONFIG_FILE) {
-      this.fstConfigFile = fstConfigFile
-    } else {
-      if (this.verifyConfigFile(fstConfigFile)) {
-        this.fstConfigFile = fstConfigFile
-      } else {
-        throw new FullstackTestingError(`Invalid config file: ${fstConfigFile}`)
-      }
-    }
-
-    this.persistMode = persistMode === true
+    if (!cachedConfigFile) throw new MissingArgumentError('cached config file path is required')
 
     this.logger = logger
-    this.config = {
-      flags: {},
-      version: '',
-      updatedAt: ''
-    }
+    this.cachedConfigFile = cachedConfigFile
+    this.reset()
   }
 
-  verifyConfigFile (fstConfigFile) {
+  /**
+   * Load the cached config
+   */
+  load () {
     try {
-      if (fs.existsSync(fstConfigFile)) {
-        const configJSON = fs.readFileSync(fstConfigFile)
-        JSON.parse(configJSON.toString())
+      if (fs.existsSync(this.cachedConfigFile)) {
+        const configJSON = fs.readFileSync(this.cachedConfigFile)
+        this.config = JSON.parse(configJSON.toString())
       }
-      return true
     } catch (e) {
-      return false
-    }
-  }
-
-  persist () {
-    this.config.updatedAt = new Date().toISOString()
-    if (this.persistMode) {
-      let configJSON = JSON.stringify(this.config)
-      fs.writeFileSync(`${this.fstConfigFile}`, configJSON)
-      configJSON = fs.readFileSync(this.fstConfigFile)
-      this.config = JSON.parse(configJSON.toString())
+      throw new FullstackTestingError(`failed to initialize config manager: ${e.message}`, e)
     }
   }
 
   /**
-   * Load and cache config on disk
-   *
-   * It overwrites previous config values using argv and store in the cached config file if any value has been changed.
-   *
-   * @param argv object containing various config related fields (e.g. argv)
-   * @param reset if we should reset old values
-   * @param flagList list of flags to be processed
-   * @returns {*} config object
+   * Reset config
    */
-  load (argv = {}, reset = false, flagList = flags.allFlags) {
-    try {
-      let writeConfig = false
-      const packageJSON = helpers.loadPackageJSON()
+  reset () {
+    this.config = {
+      flags: {},
+      version: helpers.packageVersion(),
+      updatedAt: new Date().toISOString()
+    }
+  }
 
-      this.logger.debug('Start: load config', { argv, cachedConfig: this.config })
-
-      // if config exist, then load it first
-      if (!reset && fs.existsSync(this.fstConfigFile)) {
-        const configJSON = fs.readFileSync(this.fstConfigFile)
-        this.config = JSON.parse(configJSON.toString())
-        this.logger.debug(`Loaded cached config from ${this.fstConfigFile}`, { cachedConfig: this.config })
+  /**
+   * Apply the command flags precedence
+   *
+   * It uses the below precedence for command flag values:
+   *  1. User input of the command flag
+   *  2. Cached config value of the command flag.
+   *  3. Default value of the command flag if the command is not 'init'.
+   *
+   * @param argv yargs.argv
+   * @param aliases yargv.parsed.aliases
+   * @return {*} updated argv
+   */
+  applyPrecedence (argv, aliases) {
+    for (const key of Object.keys(aliases)) {
+      const flag = flags.allFlagsMap.get(key)
+      if (flag) {
+        if (argv[key] !== undefined) {
+          // argv takes precedence, nothing to do
+        } else if (this.hasFlag(flag)) {
+          argv[key] = this.getFlag(flag)
+        } else if (argv._[0] !== 'init') {
+          argv[key] = flag.definition.defaultValue
+        }
       }
+    }
 
-      if (!this.config.flags) {
-        this.config.flags = {}
-      }
+    return argv
+  }
 
-      // we always use packageJSON version as the version, so overwrite.
-      this.config.version = packageJSON.version
+  /**
+   * Update the config using the argv
+   *
+   * @param argv list of yargs argv
+   * @param persist
+   */
+  update (argv = {}, persist = false) {
+    if (argv && Object.keys(argv).length > 0) {
+      for (const flag of flags.allFlags) {
+        if (flag.name === flags.force.name) {
+          continue // we don't want to cache force flag
+        }
 
-      // extract flags from argv
-      if (argv && Object.keys(argv).length > 0) {
-        for (const flag of flagList) {
-          if (flag.name === flags.force.name) {
-            continue // we don't want to cache force flag
-          }
+        if (argv[flag.name] === '' &&
+          [flags.namespace.name, flags.clusterName.name, flags.chartDirectory.name].includes(flag.name)) {
+          continue // don't cache empty namespace, clusterName, or chartDirectory
+        }
 
-          if (argv[flag.name] === '' &&
-            [flags.namespace.name, flags.clusterName.name, flags.chartDirectory.name].includes(flag.name)) {
-            continue // don't cache empty namespace, clusterName, or chartDirectory
-          }
+        if (argv[flag.name] !== undefined) {
+          let val = argv[flag.name]
+          switch (flag.definition.type) {
+            case 'string':
+              if (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name) {
+                this.logger.debug(`Resolving directory path for '${flag.name}': ${val}`)
+                val = paths.resolve(val)
+              }
+              this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
+              this.config.flags[flag.name] = `${val}` // force convert to string
+              break
 
-          if (argv[flag.name] !== undefined) {
-            let val = argv[flag.name]
-            switch (flag.definition.type) {
-              case 'string':
-                if (val) {
-                  if (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name) {
-                    this.logger.debug(`Resolving directory path for '${flag.name}': ${val}`)
-                    val = paths.resolve(val)
-                  }
-                  this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
-                  this.config.flags[flag.name] = val
-                  writeConfig = true
+            case 'number':
+              this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
+              try {
+                if (flags.integerFlags.has(flag.name)) {
+                  this.config.flags[flag.name] = Number.parseInt(val)
+                } else {
+                  this.config.flags[flag.name] = Number.parseFloat(val)
                 }
-                break
+              } catch (e) {
+                throw new FullstackTestingError(`invalid number value '${val}': ${e.message}`, e)
+              }
+              break
 
-              case 'number':
-              case 'boolean':
-                this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
-                this.config.flags[flag.name] = val
-                writeConfig = true
-                break
+            case 'boolean':
+              this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
+              this.config.flags[flag.name] = (val === true) || (val === 'true') // use comparison to enforce boolean value
+              break
 
-              default:
-                throw new FullstackTestingError(`Unsupported field type for flag '${flag.name}': ${flag.definition.type}`)
-            }
+            default:
+              throw new FullstackTestingError(`Unsupported field type for flag '${flag.name}': ${flag.definition.type}`)
           }
-        }
-
-        // store last command that was run
-        if (argv._) {
-          this.config.lastCommand = argv._
         }
       }
 
-      // store CLI config
-      if (reset || writeConfig) {
+      // store last command that was run
+      if (argv._) {
+        this.config.lastCommand = argv._
+      }
+
+      this.config.updatedAt = new Date().toISOString()
+
+      if (persist) {
         this.persist()
       }
+    }
+  }
 
-      this.logger.debug('Finish: load config', { argv, cachedConfig: this.config })
+  /**
+   * Persist the config in the cached config file
+   */
+  persist () {
+    try {
+      this.config.updatedAt = new Date().toISOString()
+      let configJSON = JSON.stringify(this.config)
+      fs.writeFileSync(`${this.cachedConfigFile}`, configJSON)
 
-      // set dev mode for logger if necessary
-      this.logger.setDevMode(this.getFlag(flags.devMode))
-
-      return this.config
+      // refresh config with the file contents
+      configJSON = fs.readFileSync(this.cachedConfigFile)
+      this.config = JSON.parse(configJSON.toString())
     } catch (e) {
-      throw new FullstackTestingError(`failed to load config: ${e.message}`, e)
+      throw new FullstackTestingError(`failed to persis config: ${e.message}`, e)
     }
   }
 
@@ -209,13 +224,5 @@ export class ConfigManager {
    */
   getUpdatedAt () {
     return this.config.updatedAt
-  }
-
-  /**
-   * Get last command
-   * @return {*}
-   */
-  getLastCommand () {
-    return this.config.lastCommand
   }
 }

--- a/solo/src/core/config_manager.mjs
+++ b/solo/src/core/config_manager.mjs
@@ -80,25 +80,24 @@ export class ConfigManager {
    */
   load (argv = {}, reset = false, flagList = flags.allFlags) {
     try {
-      let config = {}
       let writeConfig = false
       const packageJSON = helpers.loadPackageJSON()
 
-      this.logger.debug('Start: load config', { argv, cachedConfig: config })
+      this.logger.debug('Start: load config', { argv, cachedConfig: this.config })
 
       // if config exist, then load it first
       if (!reset && fs.existsSync(this.fstConfigFile)) {
         const configJSON = fs.readFileSync(this.fstConfigFile)
-        config = JSON.parse(configJSON.toString())
-        this.logger.debug(`Loaded cached config from ${this.fstConfigFile}`, { cachedConfig: config })
+        this.config = JSON.parse(configJSON.toString())
+        this.logger.debug(`Loaded cached config from ${this.fstConfigFile}`, { cachedConfig: this.config })
       }
 
-      if (!config.flags) {
-        config.flags = {}
+      if (!this.config.flags) {
+        this.config.flags = {}
       }
 
       // we always use packageJSON version as the version, so overwrite.
-      config.version = packageJSON.version
+      this.config.version = packageJSON.version
 
       // extract flags from argv
       if (argv && Object.keys(argv).length > 0) {
@@ -122,7 +121,7 @@ export class ConfigManager {
                     val = paths.resolve(val)
                   }
                   this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
-                  config.flags[flag.name] = val
+                  this.config.flags[flag.name] = val
                   writeConfig = true
                 }
                 break
@@ -130,7 +129,7 @@ export class ConfigManager {
               case 'number':
               case 'boolean':
                 this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)
-                config.flags[flag.name] = val
+                this.config.flags[flag.name] = val
                 writeConfig = true
                 break
 
@@ -142,17 +141,16 @@ export class ConfigManager {
 
         // store last command that was run
         if (argv._) {
-          config.lastCommand = argv._
+          this.config.lastCommand = argv._
         }
       }
 
       // store CLI config
-      this.config = config
       if (reset || writeConfig) {
         this.persist()
       }
 
-      this.logger.debug('Finish: load config', { argv, cachedConfig: config })
+      this.logger.debug('Finish: load config', { argv, cachedConfig: this.config })
 
       // set dev mode for logger if necessary
       this.logger.setDevMode(this.getFlag(flags.devMode))

--- a/solo/src/index.mjs
+++ b/solo/src/index.mjs
@@ -90,12 +90,11 @@ export function main (argv) {
         }
       }
 
-      // Update config manager and persist the config.
+      // Update config manager and persist the config using the argv
       // Note: Because of this centralized loading, we really don't need to load argv in configManager later in
       // the command execution handlers. However, we are loading argv again in the command handlers to facilitate testing
       // with argv injection into the command handlers.
-      configManager.load(argv)
-      configManager.persist()
+      configManager.load(argv, true) // here reset = true means it won't reload cached config file and persist the new config
 
       logger.showUser(chalk.cyan('\n******************************* Solo *********************************************'))
       logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(configManager.getVersion()))

--- a/solo/src/index.mjs
+++ b/solo/src/index.mjs
@@ -65,36 +65,23 @@ export function main (argv) {
 
     const processArguments = (argv, yargs) => {
       if (argv._[0] === 'init') {
-        configManager.load({}, true) // reset cached config
+        configManager.reset()
       } else {
         configManager.load()
       }
 
-      // load cluster name and namespace from kubernetes context
+      // Set default cluster name and namespace from kubernetes context
+      // these will be overwritten if user has entered the flag values explicitly
       configManager.setFlag(flags.clusterName, cluster.name)
       if (context.namespace) {
-        // this will be overwritten if user has passed --namespace flag
         configManager.setFlag(flags.namespace, context.namespace)
       }
 
-      for (const key of Object.keys(yargs.parsed.aliases)) {
-        const flag = flags.allFlagsMap.get(key)
-        if (flag) {
-          if (argv[key] !== undefined) {
-            // argv takes precedence, nothing to do
-          } else if (configManager.hasFlag(flag)) {
-            argv[key] = configManager.getFlag(flag)
-          } else if (argv._[0] !== 'init') {
-            argv[key] = flag.definition.defaultValue
-          }
-        }
-      }
+      // apply precedence for flags
+      argv = configManager.applyPrecedence(argv, yargs.parsed.aliases)
 
-      // Update config manager and persist the config using the argv
-      // Note: Because of this centralized loading, we really don't need to load argv in configManager later in
-      // the command execution handlers. However, we are loading argv again in the command handlers to facilitate testing
-      // with argv injection into the command handlers.
-      configManager.load(argv, true) // here reset = true means it won't reload cached config file and persist the new config
+      // update and persist config
+      configManager.update(argv, true)
 
       logger.showUser(chalk.cyan('\n******************************* Solo *********************************************'))
       logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(configManager.getVersion()))
@@ -115,7 +102,7 @@ export function main (argv) {
       .option(flags.devMode.name, flags.devMode.definition)
       .wrap(120)
       .demand(1, 'Select a command')
-      .middleware(processArguments, true)
+      .middleware(processArguments, false) // applyBeforeValidate = false as otherwise middleware is called twice
       .parse()
   } catch (e) {
     logger.showUserError(e)

--- a/solo/test/unit/core/config_manager.test.mjs
+++ b/solo/test/unit/core/config_manager.test.mjs
@@ -14,107 +14,256 @@
  * limitations under the License.
  *
  */
-import { describe, expect, it } from '@jest/globals'
-import { ConfigManager, logging } from '../../../src/core/index.mjs'
+import { afterAll, describe, expect, it } from '@jest/globals'
+import os from 'os'
+import path from 'path'
+import { ConfigManager } from '../../../src/core/index.mjs'
 import * as flags from '../../../src/commands/flags.mjs'
-import { v4 as uuid4 } from 'uuid'
 import fs from 'fs'
+import { testLogger } from '../../test_util.js'
+import * as helpers from '../../../src/core/helpers.mjs'
 
 describe('ConfigManager', () => {
-  describe('empty config file', () => {
-    const testLogger = logging.NewLogger('debug')
-    const cm = new ConfigManager(testLogger)
-    it('should be able to load cached config file with null argv', () => {
-      cm.load(null)
-      expect(cm.config).not.toBeNull()
-      expect(cm.config.version).not.toBeNull()
-      expect(cm.config.flags).not.toBeNull()
-      expect(cm.config.updatedAt).not.toBeNull()
+  it('should persist config', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-'))
+    const tmpFile = path.join(tmpDir, 'test.json')
+
+    expect(fs.existsSync(tmpFile)).toBeFalsy()
+    const cm = new ConfigManager(testLogger, tmpFile)
+    cm.persist()
+    expect(fs.existsSync(tmpFile)).toBeTruthy()
+
+    const configJSON = fs.readFileSync(tmpFile)
+    const cachedConfig = JSON.parse(configJSON.toString())
+
+    expect(cachedConfig.version).toStrictEqual(helpers.packageVersion())
+    expect(cachedConfig.flags).toStrictEqual({})
+    expect(cachedConfig.updatedAt).not.toStrictEqual('')
+
+    expect(cachedConfig.updatedAt).toStrictEqual(cm.getUpdatedAt())
+    expect(cachedConfig.version).toStrictEqual(cm.getVersion())
+    expect(cachedConfig.flags).toStrictEqual(cm.config.flags)
+
+    fs.rmSync(tmpDir, { recursive: true })
+  })
+
+  describe('update values using argv', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-'))
+    const tmpFile = path.join(tmpDir, 'test.json')
+
+    it('should update string flag value', () => {
+      const cm = new ConfigManager(testLogger, tmpFile)
+      const argv = {}
+      argv[flags.releaseTag.name] = 'v0.42.5'
+
+      cm.update(argv)
+      expect(cm.getFlag(flags.releaseTag)).toStrictEqual(argv[flags.releaseTag.name])
+
+      // ensure non-string values are converted to string
+      cm.reset()
+      argv[flags.releaseTag.name] = true
+      cm.update(argv)
+      expect(cm.getFlag(flags.releaseTag)).not.toStrictEqual(argv[flags.releaseTag.name])
+      expect(cm.getFlag(flags.releaseTag)).toStrictEqual(`${argv[flags.releaseTag.name]}`)
     })
 
-    it('should be able to refresh config from argv', () => {
-      cm.load()
-      expect(cm.config).not.toBeNull()
-      expect(cm.config.version).not.toBeNull()
-      expect(cm.config.flags).not.toBeNull()
-      expect(cm.config.updatedAt).not.toBeNull()
-
-      const previousNamespace = cm.getFlag(flags.namespace)
-      const previousUpdatedAt = cm.config.updatedAt
-
+    it('should update number flag value', () => {
+      const cm = new ConfigManager(testLogger, tmpFile)
       const argv = {}
-      argv[flags.namespace.name] = uuid4()
-      cm.load(argv)
-      expect(cm.getFlag(flags.namespace)).not.toBe(previousNamespace)
-      expect(cm.getFlag(flags.namespace)).toBe(argv[flags.namespace.name])
-      expect(cm.config.updatedAt).not.toBe(previousUpdatedAt)
+      argv[flags.replicaCount.name] = 1
+
+      cm.update(argv)
+      expect(cm.getFlag(flags.replicaCount)).toStrictEqual(argv[flags.replicaCount.name])
+
+      // ensure string values are converted to integer
+      cm.reset()
+      argv[flags.replicaCount.name] = '1'
+      cm.update(argv)
+      expect(cm.getFlag(flags.replicaCount)).not.toStrictEqual(argv[flags.replicaCount.name])
+      expect(cm.getFlag(flags.replicaCount)).toStrictEqual(Number.parseInt(argv[flags.replicaCount.name]))
+    })
+
+    it('should update boolean flag value', () => {
+      const cm = new ConfigManager(testLogger, tmpFile)
+
+      // boolean values should work
+      const argv = {}
+      argv[flags.devMode.name] = true
+      cm.update(argv)
+      expect(cm.getFlag(flags.devMode)).toStrictEqual(argv[flags.devMode.name])
+
+      // ensure string "false" is converted to boolean
+      cm.reset()
+      argv[flags.devMode.name] = 'false'
+      cm.update(argv)
+      expect(cm.getFlag(flags.devMode)).not.toStrictEqual(argv[flags.devMode.name])
+      expect(cm.getFlag(flags.devMode)).toStrictEqual(false)
+
+      // ensure string "true" is converted to boolean
+      cm.reset()
+      argv[flags.devMode.name] = 'true'
+      cm.update(argv)
+      expect(cm.getFlag(flags.devMode)).not.toStrictEqual(argv[flags.devMode.name])
+      expect(cm.getFlag(flags.devMode)).toStrictEqual(true)
+    })
+
+    afterAll(() => {
+      fs.rmdirSync(tmpDir, { recursive: true })
     })
   })
-  describe('ConfigManager with loaded configs', () => {
-    const testLogger = logging.NewLogger('debug')
-    const configFilePath = process.cwd() + '/test/data/solo-test-1.config'
-    const cm = new ConfigManager(testLogger, configFilePath, false)
 
-    it('should be able to load a config file override in the constructor',
-      () => {
-        cm.load()
-        expect(cm.config).not.toBeNull()
-      })
-    it('config file match, dev=false', () => {
+  describe('should apply precedence', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'config-'))
+    const tmpFile = path.join(tmpDir, 'test.json')
+    const aliases = {}
+    aliases[flags.devMode.name] = [flags.devMode.name, flags.devMode.definition.alias] // mock
+
+    it('should take user input as the first preference', () => {
+      // Given: config has value, argv has a different value
+      // Expected:  argv should retain the value
+      const cm = new ConfigManager(testLogger, tmpFile)
+      cm.setFlag(flags.devMode, false)
+      expect(cm.getFlag(flags.devMode)).toBeFalsy()
+
+      const argv = {}
+      argv[flags.devMode.name] = true // force flag is set in argv
+
+      const argv2 = cm.applyPrecedence(argv, aliases)
+      expect(cm.getFlag(flags.devMode)).toBeFalsy() // shouldn't have changed the config yet
+      expect(argv2[flags.devMode.name]).toBeTruthy() // retain the value
+    })
+
+    it('should take cached config as the second preference', () => {
+      // Given: config has value, argv doesn't have the flag value
+      // Expected:  argv should inherit the flag value from cached config
+      const cm = new ConfigManager(testLogger, tmpFile)
+
+      cm.setFlag(flags.devMode, false)
+      expect(cm.getFlag(flags.devMode)).toBeFalsy()
+
+      const argv = {} // force flag is not set in argv
+      const argv2 = cm.applyPrecedence(argv, aliases)
+      expect(cm.getFlag(flags.devMode)).toBeFalsy() // shouldn't have changed
+      expect(argv2[flags.devMode.name]).toStrictEqual(cm.getFlag(flags.devMode)) // should inherit from config
+    })
+
+    it('should take default as the last preference', () => {
+      // Given: neither config nor argv has the flag value set
+      // Expected:  argv should inherit the default flag value
+      const cm = new ConfigManager(testLogger, tmpFile)
+      expect(cm.hasFlag(flags.devMode)).toBeFalsy() // shouldn't have set
+
+      const argv = { _: ['node', 'setup'] }// force flag is not set in argv and command is not init
+      const argv2 = cm.applyPrecedence(argv, aliases)
+      expect(cm.hasFlag(flags.devMode)).toBeFalsy() // shouldn't have set
+      expect(argv2[flags.devMode.name]).toBeFalsy() // should have set from the default
+    })
+
+    afterAll(() => {
+      fs.rmdirSync(tmpDir, { recursive: true })
+    })
+  })
+
+  describe('load a cached config file', () => {
+    const configFilePath = process.cwd() + '/test/data/solo-test-1.config'
+    const cm = new ConfigManager(testLogger, configFilePath)
+    cm.load()
+
+    it('config file match: dev=false', () => {
       expect(cm.config.flags[flags.devMode.name]).toBeFalsy()
     })
-    it('config file match, namespace=solo-user', () => {
+
+    it('config file match: namespace=solo-user', () => {
       expect(cm.config.flags[flags.namespace.name]).toBe('solo-user')
     })
-    it('config file match, chartDirectory is empty', () => {
+
+    it('config file match: chartDirectory is empty', () => {
       expect(cm.config.flags[flags.chartDirectory.name]).toBe('')
     })
-    it('config file match, clusterName=kind-kind', () => {
+
+    it('config file match: clusterName=kind-kind', () => {
       expect(cm.config.flags[flags.clusterName.name]).toBe('kind-kind')
     })
-    it('config file match, deployPrometheusStack=false', () => {
+
+    it('config file match: deployPrometheusStack=false', () => {
       expect(cm.config.flags[flags.deployPrometheusStack.name]).toBeFalsy()
     })
-    it('config file match, deployMinio=false', () => {
+
+    it('config file match: deployMinio=false', () => {
       expect(cm.config.flags[flags.deployMinio.name]).toBeFalsy()
     })
-    it('config file match, deployCertManager=false', () => {
+
+    it('config file match: deployCertManager=false', () => {
       expect(cm.config.flags[flags.deployCertManager.name]).toBeFalsy()
     })
-    it('config file match, deployCertManagerCrds=false', () => {
+
+    it('config file match: deployCertManagerCrds=false', () => {
       expect(cm.config.flags[flags.deployCertManagerCrds.name]).toBeFalsy()
     })
+
     it('not set, it should be undefined', () => {
       expect(cm.config.flags[flags.enablePrometheusSvcMonitor.name]).toBeUndefined()
     })
+
     it('not set, it should be undefined', () => {
       expect(cm.config.flags[flags.enableHederaExplorerTls.name]).toBeUndefined()
     })
+
     it('not set, it should be undefined', () => {
       expect(cm.config.flags[flags.hederaExplorerTlsHostName.name]).toBeUndefined()
     })
+
     it('not set, it should be undefined', () => {
       expect(cm.config.flags[flags.deletePvcs.name]).toBeUndefined()
     })
   })
-  describe('ConfigManager with loaded configs and argv overrides', () => {
-    const testLogger = logging.NewLogger('debug')
+
+  describe('handle argv overrides', () => {
     const configFilePath = process.cwd() + '/test/data/solo-test-2.config'
     const cm = new ConfigManager(testLogger, configFilePath)
-    const clusterName = ''
-    const namespace = ''
-    const argv = {}
-    argv[flags.clusterName.name] = clusterName
-    argv[flags.namespace.name] = namespace
-    cm.load(argv)
     const configJSON = fs.readFileSync(process.cwd() + '/test/data/solo-test-2.config')
-    const newConfig = JSON.parse(configJSON.toString())
+    const cachedConfig = JSON.parse(configJSON.toString())
+
+    it('override config using argv', () => {
+      cm.load()
+      expect(cm.getFlag(flags.clusterName)).toBe(cachedConfig.flags[flags.clusterName.name])
+      expect(cm.getFlag(flags.namespace)).toBe(cachedConfig.flags[flags.namespace.name])
+
+      const argv = {}
+      argv[flags.clusterName.name] = 'new-cluster'
+      argv[flags.namespace.name] = 'new-namespace'
+      cm.update(argv)
+
+      expect(cm.getFlag(flags.clusterName)).toBe(argv[flags.clusterName.name])
+      expect(cm.getFlag(flags.namespace)).toBe(argv[flags.namespace.name])
+    })
 
     it('config file takes precedence over empty namespace', () => {
-      expect(newConfig.flags[flags.namespace.name]).toBe('solo-user')
+      cm.load()
+      expect(cm.getFlag(flags.clusterName)).toBe(cachedConfig.flags[flags.clusterName.name])
+      expect(cm.getFlag(flags.namespace)).toBe(cachedConfig.flags[flags.namespace.name])
+
+      const argv = {}
+      argv[flags.clusterName.name] = 'new-cluster'
+      argv[flags.namespace.name] = ''
+      cm.update(argv)
+      expect(cm.getFlag(flags.clusterName)).toBe(argv[flags.clusterName.name])
+      expect(cm.getFlag(flags.namespace)).not.toBe(argv[flags.namespace.name])
+      expect(cm.getFlag(flags.namespace)).toBe(cachedConfig.flags[flags.namespace.name])
     })
+
     it('config file takes precedence over empty cluster name', () => {
-      expect(newConfig.flags[flags.clusterName.name]).toBe('kind-kind')
+      cm.load()
+      expect(cm.getFlag(flags.clusterName)).toBe(cachedConfig.flags[flags.clusterName.name])
+      expect(cm.getFlag(flags.namespace)).toBe(cachedConfig.flags[flags.namespace.name])
+
+      const argv = {}
+      argv[flags.clusterName.name] = ''
+      argv[flags.namespace.name] = 'new-namespace'
+      cm.update(argv)
+      expect(cm.getFlag(flags.clusterName)).not.toBe(argv[flags.clusterName.name])
+      expect(cm.getFlag(flags.clusterName)).toBe(cachedConfig.flags[flags.clusterName.name])
+      expect(cm.getFlag(flags.namespace)).toBe(argv[flags.namespace.name])
     })
   })
 })


### PR DESCRIPTION
## Description

This pull request changes the following:

- fix: cluster-name in the config is not overwritten based on current kubernetes context
- fix: refactor config manager with each function having a single responsibility to avoid confusion
- fix: parsing different types of values (string, integer/float, boolean)
- test: add more unit tests

### Related Issues

- Closes #
