### PR TITLE
fix: use default values for all flags during init

### DIFF
--- a/solo/src/commands/cluster.mjs
+++ b/solo/src/commands/cluster.mjs
@@ -69,7 +69,7 @@ export class ClusterCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.clusterSetupNamespace,
             flags.chartDirectory,
@@ -175,7 +175,7 @@ export class ClusterCommand extends BaseCommand {
             process.exit(0)
           }
 
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           const clusterName = self.configManager.getFlag(flags.clusterName)
           const clusterSetupNamespace = self.configManager.getFlag(flags.clusterSetupNamespace)
           ctx.config = {

--- a/solo/src/commands/init.mjs
+++ b/solo/src/commands/init.mjs
@@ -152,7 +152,15 @@ export class InitCommand extends BaseCommand {
       command: 'init',
       desc: 'Initialize local environment and default flags',
       builder: y => {
-        flags.setCommandFlags(y, ...flags.allFlags)
+        flags.setCommandFlags(y,
+          flags.releaseTag,
+          flags.nodeIDs,
+          flags.namespace,
+          flags.clusterSetupNamespace,
+          flags.cacheDir,
+          flags.chartDirectory,
+          flags.keyFormat,
+          )
       },
       handler: (argv) => {
         initCmd.init(argv).then(r => {

--- a/solo/src/commands/network.mjs
+++ b/solo/src/commands/network.mjs
@@ -118,7 +118,7 @@ export class NetworkCommand extends BaseCommand {
       flags.enablePrometheusSvcMonitor
     ]
 
-    this.configManager.load(argv)
+    this.configManager.update(argv)
     this.logger.debug('Loaded cached config', { config: this.configManager.config })
     await prompts.execute(task, this.configManager, flagList)
 
@@ -243,7 +243,7 @@ export class NetworkCommand extends BaseCommand {
             }
           }
 
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.namespace,
             flags.deletePvcs

--- a/solo/src/commands/node.mjs
+++ b/solo/src/commands/node.mjs
@@ -159,7 +159,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.namespace,
             flags.nodeIDs,
@@ -409,7 +409,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.namespace,
             flags.nodeIDs
@@ -495,7 +495,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.namespace,
             flags.nodeIDs
@@ -557,7 +557,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.nodeIDs,
             flags.cacheDir,

--- a/solo/src/commands/relay.mjs
+++ b/solo/src/commands/relay.mjs
@@ -86,7 +86,7 @@ export class RelayCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
 
           // extract config values
           const valuesFile = self.configManager.getFlag(flags.valuesFile)
@@ -176,7 +176,7 @@ export class RelayCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.load(argv)
+          self.configManager.update(argv)
 
           // extract config values
           const nodeIds = self.configManager.getFlag(flags.nodeIDs)

--- a/solo/src/core/config_manager.mjs
+++ b/solo/src/core/config_manager.mjs
@@ -83,7 +83,7 @@ export class ConfigManager {
           // argv takes precedence, nothing to do
         } else if (this.hasFlag(flag)) {
           argv[key] = this.getFlag(flag)
-        } else if (argv._[0] !== 'init') {
+        } else {
           argv[key] = flag.definition.defaultValue
         }
       }

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -107,15 +107,8 @@ describe.each([
     argv[flags.clusterName.name] = 'kind-solo-e2e'
     argv[flags.clusterSetupNamespace.name] = 'solo-e2e-cluster'
     argv[flags.updateAccountKeys.name] = true
-    configManager.update(argv, true)
-
+    configManager.update(argv)
     const nodeIds = argv[flags.nodeIDs.name].split(',')
-
-    beforeAll(() => {
-      configManager.load()
-      configManager.update(argv)
-      argv[flags.namespace.name] = configManager.getFlag(flags.namespace)
-    })
 
     afterEach(() => {
       sleep(5).then().catch() // give a few ticks so that connections can close

--- a/solo/test/e2e/commands/node.test.mjs
+++ b/solo/test/e2e/commands/node.test.mjs
@@ -148,7 +148,6 @@ describe.each([
     argv[flags.cacheDir.name] = cacheDir
     argv[flags.force.name] = false
     argv[flags.chainId.name] = constants.HEDERA_CHAIN_ID
-    argv[flags.chainId.name] = constants.HEDERA_CHAIN_ID
     argv[flags.generateGossipKeys.name] = false
     argv[flags.generateTlsKeys.name] = true
     argv[flags.applicationProperties.name] = flags.applicationProperties.definition.defaultValue
@@ -161,6 +160,7 @@ describe.each([
 
     beforeAll(() => {
       configManager.load()
+      configManager.update(argv)
       argv[namespace] = configManager.getFlag(flags.namespace)
     })
 
@@ -170,6 +170,7 @@ describe.each([
         await shellRunner.run(`test/scripts/gen-legacy-keys.sh ${nodeIds.join(',')} ${path.join(cacheDir, 'keys')}`)
       }
     }, 60000)
+
     it('node setup should succeed', async () => {
       expect.assertions(1)
       try {

--- a/solo/test/unit/core/config_manager.test.mjs
+++ b/solo/test/unit/core/config_manager.test.mjs
@@ -126,7 +126,7 @@ describe('ConfigManager', () => {
       expect(cm.getFlag(flags.devMode)).toBeFalsy()
 
       const argv = {}
-      argv[flags.devMode.name] = true // force flag is set in argv
+      argv[flags.devMode.name] = true // devMode flag is set in argv but cached config has it
 
       const argv2 = cm.applyPrecedence(argv, aliases)
       expect(cm.getFlag(flags.devMode)).toBeFalsy() // shouldn't have changed the config yet
@@ -141,7 +141,7 @@ describe('ConfigManager', () => {
       cm.setFlag(flags.devMode, false)
       expect(cm.getFlag(flags.devMode)).toBeFalsy()
 
-      const argv = {} // force flag is not set in argv
+      const argv = {} // devMode flag is not set in argv
       const argv2 = cm.applyPrecedence(argv, aliases)
       expect(cm.getFlag(flags.devMode)).toBeFalsy() // shouldn't have changed
       expect(argv2[flags.devMode.name]).toStrictEqual(cm.getFlag(flags.devMode)) // should inherit from config
@@ -153,7 +153,7 @@ describe('ConfigManager', () => {
       const cm = new ConfigManager(testLogger, tmpFile)
       expect(cm.hasFlag(flags.devMode)).toBeFalsy() // shouldn't have set
 
-      const argv = { _: ['node', 'setup'] }// force flag is not set in argv and command is not init
+      const argv = {} // devMode flag is not set in argv and cached config doesn't have it either
       const argv2 = cm.applyPrecedence(argv, aliases)
       expect(cm.hasFlag(flags.devMode)).toBeFalsy() // shouldn't have set
       expect(argv2[flags.devMode.name]).toBeFalsy() // should have set from the default


### PR DESCRIPTION
## Description

This pull request changes the following:

- use default values for all flags during init
- invoke configManager.update(argv) instead of configManager.load(argv)

### Related Issues

- Closes #
