### PR TITLE
fix(docker): update location for entrypoint.sh

### DIFF
--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -62,7 +62,9 @@ spec:
           emptyDir: {}
         - name: hgcapp-event-streams
           emptyDir: {}
-        - name: hgcapp-services-hedera
+        - name: hgcapp-data-saved
+          emptyDir: {}
+        - name: hgcapp-data-stats
           emptyDir: {}
         {{- if $otelCollector.enabled }}
         - name: otel-collector-volume
@@ -87,8 +89,10 @@ spec:
             mountPath: /opt/hgcapp/recordStreams
           - name: hgcapp-event-streams
             mountPath: /opt/hgcapp/eventsStreams
-          - name: hgcapp-services-hedera
-            mountPath: opt/hgcapp/services-hedera
+          - name: hgcapp-data-saved
+            mountPath: opt/hgcapp/services-hedera/HapApp2.0/data/saved
+          - name: hgcapp-data-stats
+            mountPath: opt/hgcapp/services-hedera/HapApp2.0/data/stats
         env:
           {{- include "fullstack.defaultEnvVars" . | nindent 10 }}
       {{- if $balanceUploader.enabled }}
@@ -283,9 +287,10 @@ spec:
         securityContext:
           {{- include "fullstack.hedera.security.context" . | nindent 10 }}
         volumeMounts:
-          - name: hgcapp-services-hedera
-            mountPath: opt/hgcapp/services-hedera
-            subPath: data
+          - name: hgcapp-data-saved
+            mountPath: opt/hgcapp/services-hedera/HapiApp2.0/data/saved
+          - name: hgcapp-data-stats
+            mountPath: opt/hgcapp/services-hedera/HapiApp2.0/data/stats
         env:
           - name: BACKUP_UPLOADER_BUCKET_1
             value: {{ default $defaults.sidecars.backupUploader.config.backupBucket ($backupUploader.config).backupBucket | quote }}

--- a/docker/ubi8-init-java17/Dockerfile
+++ b/docker/ubi8-init-java17/Dockerfile
@@ -98,16 +98,13 @@ RUN mkdir -p "/opt/hgcapp" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"
 
 # Add the entrypoint script and systemd service file
-ADD entrypoint.sh /etc/network-node/
+ADD entrypoint.sh /opt/hgcapp/services-hedera/HapiApp2.0/
 ADD network-node.service /usr/lib/systemd/system/
 
 # Ensure proper file permissions
-RUN chmod -R +x /etc/network-node/entrypoint.sh && \
+RUN chmod -R +x /opt/hgcapp/services-hedera/HapiApp2.0/entrypoint.sh && \
+    touch /opt/hgcapp/services-hedera/HapiApp2.0/application.env && \
     chown -R 2000:2000 /opt/hgcapp/
-
-RUN mkdir -p /etc/network-node && \
-    touch /etc/network-node/application.env && \
-    chown -R 2000:2000 /etc/network-node
 
 # Expose TCP/UDP Port Definitions
 EXPOSE 50111/tcp 50211/tcp 50212/tcp

--- a/docker/ubi8-init-java17/network-node.service
+++ b/docker/ubi8-init-java17/network-node.service
@@ -9,10 +9,10 @@ User=hedera
 Group=hedera
 
 PassEnvironment=JAVA_HOME JAVA_OPTS JAVA_HEAP_MIN JAVA_HEAP_MAX PATH APP_HOME
-EnvironmentFile=/etc/network-node/application.env
+EnvironmentFile=/opt/hgcapp/services-hedera/HapiApp2.0/application.env
 
 WorkingDirectory=/opt/hgcapp/services-hedera/HapiApp2.0
-ExecStart=/usr/bin/bash /etc/network-node/entrypoint.sh
+ExecStart=/usr/bin/bash /opt/hgcapp/services-hedera/HapiApp2.0/entrypoint.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/docker/ubi8-init-java21/Dockerfile
+++ b/docker/ubi8-init-java21/Dockerfile
@@ -101,16 +101,13 @@ RUN mkdir -p "/opt/hgcapp" && \
     mkdir -p "/opt/hgcapp/services-hedera/HapiApp2.0/data/upgrade"
 
 # Add the entrypoint script and systemd service file
-ADD entrypoint.sh /etc/network-node/
+ADD entrypoint.sh /opt/hgcapp/services-hedera/HapiApp2.0/
 ADD network-node.service /usr/lib/systemd/system/
 
 # Ensure proper file permissions
-RUN chmod -R +x /etc/network-node/entrypoint.sh && \
+RUN chmod -R +x /opt/hgcapp/services-hedera/HapiApp2.0/entrypoint.sh && \
+    touch /opt/hgcapp/services-hedera/HapiApp2.0/application.env && \
     chown -R 2000:2000 /opt/hgcapp/
-
-RUN mkdir -p /etc/network-node && \
-    touch /etc/network-node/application.env && \
-    chown -R 2000:2000 /etc/network-node
 
 # Expose TCP/UDP Port Definitions
 EXPOSE 50111/tcp 50211/tcp 50212/tcp

--- a/docker/ubi8-init-java21/network-node.service
+++ b/docker/ubi8-init-java21/network-node.service
@@ -9,10 +9,10 @@ User=hedera
 Group=hedera
 
 PassEnvironment=JAVA_HOME JAVA_OPTS JAVA_HEAP_MIN JAVA_HEAP_MAX PATH APP_HOME
-EnvironmentFile=/etc/network-node/application.env
+EnvironmentFile=/opt/hgcapp/services-hedera/HapiApp2.0/application.env
 
 WorkingDirectory=/opt/hgcapp/services-hedera/HapiApp2.0
-ExecStart=/usr/bin/bash /etc/network-node/entrypoint.sh
+ExecStart=/usr/bin/bash /opt/hgcapp/services-hedera/HapiApp2.0/entrypoint.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/solo/src/core/platform_installer.mjs
+++ b/solo/src/core/platform_installer.mjs
@@ -45,14 +45,14 @@ export class PlatformInstaller {
     if (!podName) throw new MissingArgumentError('podName is required')
 
     try {
-      // reset HAPI_PATH
-      await this.k8.execContainer(podName, containerName, `rm -rf ${constants.HEDERA_HAPI_PATH}`)
+      // reset data directory
+      await this.k8.execContainer(podName, containerName, `rm -rf ${constants.HEDERA_HAPI_PATH}/data`)
 
       const paths = [
-        constants.HEDERA_HAPI_PATH,
         `${constants.HEDERA_HAPI_PATH}/data`,
         `${constants.HEDERA_HAPI_PATH}/data/apps`,
-        `${constants.HEDERA_HAPI_PATH}/data/config``${constants.HEDERA_HAPI_PATH}/data/keys`,
+        `${constants.HEDERA_HAPI_PATH}/data/config`,
+        `${constants.HEDERA_HAPI_PATH}/data/keys`,
         `${constants.HEDERA_HAPI_PATH}/data/lib`,
         `${constants.HEDERA_HAPI_PATH}/data/stats`,
         `${constants.HEDERA_HAPI_PATH}/data/saved`,

--- a/solo/src/core/platform_installer.mjs
+++ b/solo/src/core/platform_installer.mjs
@@ -35,20 +35,32 @@ export class PlatformInstaller {
     this.k8 = k8
   }
 
+  /**
+   * Setup directories
+   * @param podName
+   * @param containerName
+   * @return {Promise<boolean>}
+   */
   async setupHapiDirectories (podName, containerName = constants.ROOT_CONTAINER) {
     if (!podName) throw new MissingArgumentError('podName is required')
 
     try {
       // reset HAPI_PATH
-      await this.k8.execContainer(podName, containerName, `rm -rf ${constants.HEDERA_SERVICES_PATH}/HapiApp2.0`)
+      await this.k8.execContainer(podName, containerName, `rm -rf ${constants.HEDERA_HAPI_PATH}`)
 
       const paths = [
-        `${constants.HEDERA_HAPI_PATH}/data/keys`,
-        `${constants.HEDERA_HAPI_PATH}/data/config`
+        constants.HEDERA_HAPI_PATH,
+        `${constants.HEDERA_HAPI_PATH}/data`,
+        `${constants.HEDERA_HAPI_PATH}/data/apps`,
+        `${constants.HEDERA_HAPI_PATH}/data/config``${constants.HEDERA_HAPI_PATH}/data/keys`,
+        `${constants.HEDERA_HAPI_PATH}/data/lib`,
+        `${constants.HEDERA_HAPI_PATH}/data/stats`,
+        `${constants.HEDERA_HAPI_PATH}/data/saved`,
+        `${constants.HEDERA_HAPI_PATH}/data/upgrade`
       ]
 
       for (const p of paths) {
-        await this.k8.execContainer(podName, containerName, `mkdir -p ${p}`)
+        await this.k8.execContainer(podName, containerName, `mkdir ${p}`)
       }
 
       await this.setPathPermission(podName, constants.HEDERA_SERVICES_PATH)
@@ -122,7 +134,6 @@ export class PlatformInstaller {
     try {
       await this.copyFiles(podName, [extractScriptSrc], constants.HEDERA_USER_HOME_DIR)
       await this.k8.execContainer(podName, constants.ROOT_CONTAINER, `chmod +x ${extractScript}`)
-      await this.setupHapiDirectories(podName)
       await this.k8.execContainer(podName, constants.ROOT_CONTAINER, [extractScript, buildZip, constants.HEDERA_HAPI_PATH])
 
       return true


### PR DESCRIPTION
## Description

This pull request changes the following:

- update Dockerfile for `ubi8-init-java17` and `ubi8-init-java21` images to put entrypoint.sh in `/opt/hgcapp/services-hedera/HapiApp2.0/`
- do not reset the directory `/opt/hgcapp/services-hedera/HapiApp2.0/` during node setup anymore (as otherwise it would delete the entrypoint.sh)
- update `setupHapiDirectories` function with correct list of paths as required for e2e tests

### Related Issues

- Closes #723 
- Depends on #753 
