### PR TITLE
fix: correct path names for volumes and upgrade minio

### DIFF
--- a/charts/fullstack-deployment/Chart.lock
+++ b/charts/fullstack-deployment/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 0.86.0
 - name: tenant
   repository: https://operator.min.io/
-  version: 5.0.7
+  version: 5.0.12
 - name: acme-cluster-issuer
   repository: https://swirldslabs.github.io/swirldslabs-helm-charts
   version: 0.3.1
 - name: haproxy-ingress
   repository: https://haproxy-ingress.github.io/charts
   version: 0.14.5
-digest: sha256:a895d9b9235e22a469f2b274650fa25e2c7fd586eff205bfa473bdfd4cfd0f91
-generated: "2024-01-24T16:36:12.619906Z"
+digest: sha256:15d4cdc6b19e203dc139abc061425c2f31607c6067a260596c5354f6e9bb1cba
+generated: "2024-02-16T13:56:04.205158+11:00"

--- a/charts/fullstack-deployment/Chart.yaml
+++ b/charts/fullstack-deployment/Chart.yaml
@@ -44,7 +44,7 @@ dependencies:
 
   - name: tenant
     alias: minio-server
-    version: 5.0.7
+    version: 5.0.12
     repository: https://operator.min.io/
     condition: cloud.minio.enabled
 

--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -140,7 +140,7 @@ spec:
           - name: SIG_PRIORITIZE
             value: {{ default $defaults.sidecars.accountBalanceUploader.config.signature.prioritize (($balanceUploader.config).signature).prioritize | quote }}
           - name: BUCKET_PATH
-            value: "accountBalances/balance_{{ $node.accountId }}"
+            value: "accountBalances/balance{{ $node.accountId }}"
           - name: BUCKET_NAME
             value: {{ $cloud.buckets.streamBucket | quote }}
           - name: S3_ENABLE
@@ -205,7 +205,7 @@ spec:
           - name: SIG_PRIORITIZE
             value: {{ default $defaults.sidecars.recordStreamUploader.config.signature.prioritize (($recordStream.config).signature).prioritize | quote }}
           - name: BUCKET_PATH
-            value: "recordStreams/record_{{ $node.accountId }}"
+            value: "recordstreams/record{{ $node.accountId }}"
           - name: BUCKET_NAME
             value: {{ $cloud.buckets.streamBucket | quote }}
           - name: S3_ENABLE

--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
         volumeMounts:
           - name: hgcapp-account-balances
             mountPath: /opt/hgcapp/accountBalances
-            subPath: balance{{ $node.accountId }}
+            subPath: balance_{{ $node.accountId }}
         env:
           - name: DEBUG
             value: {{ default $defaults.sidecars.accountBalanceUploader.config.debug ($balanceUploader.config).debug | quote }}
@@ -140,7 +140,7 @@ spec:
           - name: SIG_PRIORITIZE
             value: {{ default $defaults.sidecars.accountBalanceUploader.config.signature.prioritize (($balanceUploader.config).signature).prioritize | quote }}
           - name: BUCKET_PATH
-            value: "accountBalances/balance{{ $node.accountId }}"
+            value: "accountBalances/balance_{{ $node.accountId }}"
           - name: BUCKET_NAME
             value: {{ $cloud.buckets.streamBucket | quote }}
           - name: S3_ENABLE
@@ -176,7 +176,7 @@ spec:
         volumeMounts:
           - name: hgcapp-record-streams
             mountPath: /opt/hgcapp/recordStreams
-            subPath: record{{ $node.accountId }}
+            subPath: record_{{ $node.accountId }}
         env:
           - name: DEBUG
             value: {{ default $defaults.sidecars.recordStreamUploader.config.debug ($recordStream.config).debug | quote }}
@@ -205,7 +205,7 @@ spec:
           - name: SIG_PRIORITIZE
             value: {{ default $defaults.sidecars.recordStreamUploader.config.signature.prioritize (($recordStream.config).signature).prioritize | quote }}
           - name: BUCKET_PATH
-            value: "recordstreams/record{{ $node.accountId }}"
+            value: "recordstreams/record_{{ $node.accountId }}"
           - name: BUCKET_NAME
             value: {{ $cloud.buckets.streamBucket | quote }}
           - name: S3_ENABLE
@@ -240,7 +240,7 @@ spec:
         volumeMounts:
           - name: hgcapp-event-streams
             mountPath: /opt/hgcapp/eventStreams
-            subPath: balance{{ $node.accountId }}
+            subPath: events_{{ $node.accountId }}
         env:
           - name: DEBUG
             value: {{ default $defaults.sidecars.eventStreamUploader.config.debug ($eventStream.config).debug | quote}}

--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -91,9 +91,9 @@ spec:
           - name: hgcapp-event-streams
             mountPath: /opt/hgcapp/eventsStreams
           - name: hgcapp-data-saved
-            mountPath: opt/hgcapp/services-hedera/HapApp2.0/data/saved
+            mountPath: opt/hgcapp/services-hedera/HapiApp2.0/data/saved
           - name: hgcapp-data-stats
-            mountPath: opt/hgcapp/services-hedera/HapApp2.0/data/stats
+            mountPath: opt/hgcapp/services-hedera/HapiApp2.0/data/stats
         env:
           {{- include "fullstack.defaultEnvVars" . | nindent 10 }}
       {{- if $balanceUploader.enabled }}

--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -257,9 +257,9 @@ spec:
           - name: STREAM_SIG_EXTENSION
             value: "evts_sig"
           - name: STREAM_EXTENSION
-            value: {{ default $defaults.sidecars.eventStreamUploader.config.compression ($eventStream.config).compression | ternary "evts.gz" "evts" | quote }}
+            value: "evts"
           - name: SIG_EXTENSION
-            value: {{ default $defaults.sidecars.eventStreamUploader.config.compression ($eventStream.config).compression | ternary "evts_sig.gz" "evts_sig" | quote }}
+            value: "evts_sig"
           - name: SIG_REQUIRE
             value: {{ default $defaults.sidecars.eventStreamUploader.config.signature.require (($eventStream.config).signature).require | quote }}
           - name: SIG_PRIORITIZE

--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -176,7 +176,7 @@ spec:
         volumeMounts:
           - name: hgcapp-record-streams
             mountPath: /opt/hgcapp/recordStreams
-            subPath: record_{{ $node.accountId }}
+            subPath: record{{ $node.accountId }}
         env:
           - name: DEBUG
             value: {{ default $defaults.sidecars.recordStreamUploader.config.debug ($recordStream.config).debug | quote }}
@@ -205,7 +205,7 @@ spec:
           - name: SIG_PRIORITIZE
             value: {{ default $defaults.sidecars.recordStreamUploader.config.signature.prioritize (($recordStream.config).signature).prioritize | quote }}
           - name: BUCKET_PATH
-            value: "recordstreams/record_{{ $node.accountId }}"
+            value: "recordStreams/record_{{ $node.accountId }}"
           - name: BUCKET_NAME
             value: {{ $cloud.buckets.streamBucket | quote }}
           - name: S3_ENABLE

--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -223,6 +223,8 @@ minio-server:
       name: minio-secrets
     certificate:
       requestAutoCert: false
+  environment:
+    MINIO_BROWSER_LOGIN_ANIMATION: off # https://github.com/minio/console/issues/2539#issuecomment-1619211962
 
 # hedera mirror node configuration
 hedera-mirror-node:

--- a/solo/resources/templates/settings.txt
+++ b/solo/resources/templates/settings.txt
@@ -2,7 +2,7 @@ checkSignedStateFromDisk,                      1
 csvFileName,                                   MainNetStats
 csvOutputFolder,                               data/stats
 doUpnp,                                        false
-enableEventStreaming,                          false
+enableEventStreaming,                          true
 eventsLogDir,                                  /opt/hgcapp/eventsStreams
 eventsLogPeriod,                               5
 maxEventQueueForCons,                          1000

--- a/solo/src/commands/init.mjs
+++ b/solo/src/commands/init.mjs
@@ -159,8 +159,8 @@ export class InitCommand extends BaseCommand {
           flags.clusterSetupNamespace,
           flags.cacheDir,
           flags.chartDirectory,
-          flags.keyFormat,
-          )
+          flags.keyFormat
+        )
       },
       handler: (argv) => {
         initCmd.init(argv).then(r => {

--- a/solo/src/core/platform_installer.mjs
+++ b/solo/src/core/platform_installer.mjs
@@ -41,25 +41,22 @@ export class PlatformInstaller {
    * @param containerName
    * @return {Promise<boolean>}
    */
-  async setupHapiDirectories (podName, containerName = constants.ROOT_CONTAINER) {
+  async resetHapiDirectories (podName, containerName = constants.ROOT_CONTAINER) {
     if (!podName) throw new MissingArgumentError('podName is required')
 
     try {
       // reset data directory
-      await this.k8.execContainer(podName, containerName, `rm -rf ${constants.HEDERA_HAPI_PATH}/data`)
-
-      const paths = [
-        `${constants.HEDERA_HAPI_PATH}/data`,
+      // Note: we cannot delete the data/stats and data/saved as those are volume mounted
+      const reset_paths = [
         `${constants.HEDERA_HAPI_PATH}/data/apps`,
         `${constants.HEDERA_HAPI_PATH}/data/config`,
         `${constants.HEDERA_HAPI_PATH}/data/keys`,
         `${constants.HEDERA_HAPI_PATH}/data/lib`,
-        `${constants.HEDERA_HAPI_PATH}/data/stats`,
-        `${constants.HEDERA_HAPI_PATH}/data/saved`,
         `${constants.HEDERA_HAPI_PATH}/data/upgrade`
       ]
 
-      for (const p of paths) {
+      for (const p of reset_paths) {
+        await this.k8.execContainer(podName, containerName, `rm -rf ${p}`)
         await this.k8.execContainer(podName, containerName, `mkdir ${p}`)
       }
 

--- a/solo/test/e2e/core/platform_installer_e2e.test.mjs
+++ b/solo/test/e2e/core/platform_installer_e2e.test.mjs
@@ -47,11 +47,11 @@ describe('PackageInstallerE2E', () => {
     configManager.load()
   })
 
-  describe('setupHapiDirectories', () => {
+  describe('resetHapiDirectories', () => {
     it('should succeed with valid pod', async () => {
       expect.assertions(1)
       try {
-        await expect(installer.setupHapiDirectories(podName)).resolves.toBeTruthy()
+        await expect(installer.resetHapiDirectories(podName)).resolves.toBeTruthy()
       } catch (e) {
         console.error(e)
         expect(e).toBeNull()
@@ -124,7 +124,7 @@ describe('PackageInstallerE2E', () => {
       const shellRunner = new ShellRunner(testLogger)
       await shellRunner.run(`test/scripts/gen-legacy-keys.sh node0,node1 ${keysDir}`)
 
-      await installer.setupHapiDirectories(podName)
+      await installer.resetHapiDirectories(podName)
       const fileList = await installer.copyGossipKeys(podName, tmpDir, ['node0', 'node1'], constants.KEY_FORMAT_PFX)
 
       const destDir = `${constants.HEDERA_HAPI_PATH}/data/keys`
@@ -144,7 +144,7 @@ describe('PackageInstallerE2E', () => {
       const shellRunner = new ShellRunner(testLogger)
       await shellRunner.run(`test/scripts/gen-standard-keys.sh node0,node1 ${keysDir}`)
 
-      await installer.setupHapiDirectories(podName)
+      await installer.resetHapiDirectories(podName)
       const fileList = await installer.copyGossipKeys(podName, tmpDir, ['node0', 'node1'], constants.KEY_FORMAT_PEM)
 
       const destDir = `${constants.HEDERA_HAPI_PATH}/data/keys`
@@ -174,7 +174,7 @@ describe('PackageInstallerE2E', () => {
       fs.writeFileSync(path.join(keysDir, `hedera-${nodeId}.key`), '')
       fs.writeFileSync(path.join(keysDir, `hedera-${nodeId}.crt`), '')
 
-      await installer.setupHapiDirectories(podName)
+      await installer.resetHapiDirectories(podName)
 
       const fileList = await installer.copyTLSKeys(podName, tmpDir)
 
@@ -190,7 +190,7 @@ describe('PackageInstallerE2E', () => {
   describe('copyPlatformConfigFiles', () => {
     it('should succeed to copy platform config files for node0', async () => {
       const podName = 'network-node0-0'
-      await installer.setupHapiDirectories(podName)
+      await installer.resetHapiDirectories(podName)
 
       const tmpDir = getTmpDir()
       const nodeIDs = ['node0']


### PR DESCRIPTION
## Description

This pull request changes the following:

- path name was misspelled for HapiApp2.0
- path name was incorrect for event streams
- add _ for bucket path names for consistency
- enable event streaming
- update `resetHapiDirectories` to skip resetting `HapiApp2.0/data/saved` and `HapiApp2.0/data/sats` as those are volume mounted for backup-uploader


<img width="1045" alt="Screenshot 2024-02-16 at 3 30 26 PM" src="https://github.com/hashgraph/full-stack-testing/assets/811437/20bd4fab-a0a2-4041-bc28-7c60b04c0417">


### Related Issues

- Closes #
