### PR TITLE
fix: set the mirror node importer addressbook to an invalid value to prevent it from starting

### DIFF
--- a/charts/fullstack-deployment/templates/secrets/uploder-mirror-secrets.yaml
+++ b/charts/fullstack-deployment/templates/secrets/uploder-mirror-secrets.yaml
@@ -1,8 +1,8 @@
+{{- $previous := lookup "v1" "Secret" .Release.Namespace "uploader-mirror-secrets" }}
 {{- $minio_accessKey := randAlpha 10  -}}
 {{- $minio_secretKey := randAlpha 10  -}}
-{{- $minio_config_env := printf "export MINIO_ROOT_USER=%s\nexport MINIO_ROOT_PASSWORD=%s" $minio_accessKey $minio_secretKey -}}
+{{- $minio_config_env := printf "export MINIO_ROOT_USER=%s\nexport MINIO_ROOT_PASSWORD=%s" (coalesce ((($previous).data).S3_ACCESS_KEY) $minio_accessKey) (coalesce ((($previous).data).S3_SECRET_KEY) $minio_secretKey) -}}
 {{- $minio_url := printf "http://%s-hl:9000" (index $.Values "minio-server" "tenant" "name") -}}
-
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,12 +18,12 @@ metadata:
   name: uploader-mirror-secrets
 type: Opaque
 data:
-  S3_ACCESS_KEY: {{ $minio_accessKey | b64enc }}
-  S3_SECRET_KEY: {{ $minio_secretKey | b64enc }}
+  S3_ACCESS_KEY: {{ coalesce ((($previous).data).S3_ACCESS_KEY) ($minio_accessKey | b64enc) }}
+  S3_SECRET_KEY: {{ coalesce ((($previous).data).S3_SECRET_KEY) ($minio_secretKey | b64enc) }}
   # The below keys will be ignored by the uploader side cars
   # These will be used by mirror node to connect to minio
   HEDERA_MIRROR_IMPORTER_DOWNLOADER_SOURCES_0_TYPE: {{ "S3" | b64enc }}
   HEDERA_MIRROR_IMPORTER_DOWNLOADER_SOURCES_0_URI: {{ $minio_url |b64enc }}
-  HEDERA_MIRROR_IMPORTER_DOWNLOADER_SOURCES_0_CREDENTIALS_ACCESSKEY: {{ $minio_accessKey | b64enc }}
-  HEDERA_MIRROR_IMPORTER_DOWNLOADER_SOURCES_0_CREDENTIALS_SECRETKEY: {{ $minio_secretKey | b64enc }}
+  HEDERA_MIRROR_IMPORTER_DOWNLOADER_SOURCES_0_CREDENTIALS_ACCESSKEY: {{ coalesce ((($previous).data).S3_ACCESS_KEY) ($minio_accessKey | b64enc) }}
+  HEDERA_MIRROR_IMPORTER_DOWNLOADER_SOURCES_0_CREDENTIALS_SECRETKEY: {{ coalesce ((($previous).data).S3_SECRET_KEY) ($minio_secretKey | b64enc) }}
 ---

--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -228,7 +228,7 @@ minio-server:
 
 # hedera mirror node configuration
 hedera-mirror-node:
-  enabled: true
+  enabled: false # set to false during first deployment, then do an upgrade with it enabled and supply the base64 encoded addressbook
   labels:
     fullstack.hedera.com/testSuiteName: ""
     fullstack.hedera.com/testName: ""
@@ -267,9 +267,8 @@ hedera-mirror-node:
           name: "{{ .Release.Name }}-redis"
       - secretRef:
           name: uploader-mirror-secrets
-    # This is a corrupted addressbook to prevent mirror importer from starting correctly
     # The addressbook.bin file updates will be handled by infrastructure code or solo
-    addressBook: ZmFpbC1pbXBvcnRlci1zdGFydC11cAo=
+    addressBook: ""
     config:
       # importer is a springboot app, its application.yaml configuration starts here
       # This config is mounted at [/usr/etc/hedera/application.yaml] in the importer pod
@@ -363,7 +362,7 @@ haproxy-ingress:
 
 # hedera-mirror-node-explorer configuration
 hedera-explorer:
-  enabled: true
+  enabled: false # set to false during first deployment, then do an upgrade with it enabled and supply the base64 encoded addressbook
   # leave blank to use default, set if you have multiple deployments in a cluster to make it unique
   selfSignedCertClusterIssuer: '{{ .Values.global.namespaceOverride | default .Release.Namespace | printf "%s-self-signed-cluster-issuer" }}'
   certClusterIssuerType: "self-signed" # "acme-staging", "acme-prod", or "self-signed"

--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -267,9 +267,9 @@ hedera-mirror-node:
           name: "{{ .Release.Name }}-redis"
       - secretRef:
           name: uploader-mirror-secrets
-    # This is a single node address book, node account id = 0.0.3
-    # The addressbook.bin file updates will be handled by infrastructure code
-    addressBook: CvYGCgwxMC45Ni4xMzEuMzYaBTAuMC4zIswGMzA4MjAxYTIzMDBkMDYwOTJhODY0ODg2ZjcwZDAxMDEwMTA1MDAwMzgyMDE4ZjAwMzA4MjAxOGEwMjgyMDE4MTAwYTEyMDA2ZjI1MjcyNDJjZDdmNTNiOWM0ZmQ1ZGU4NjljNTYyZmY0ZWQ4YTRhYjNhNjI5NjNmM2Y4MTg4YmU3OGYyNThlYWY0MmI5YzNlM2U4ZjU4Njk3MTYwNDEzYmJmNzdhYWRmYWYwZDlmZmQ4Njk4NGIzYmM0ZmI1ZjAyZTExZThhY2I2ZWM2N2U0MjY0YWRkY2ExM2ZmZGU4MzY3NTc4YzI3OTJmYzZhZTMyNmU3YjM0ODU2ZDIzZjAyNTc0ZjVhMjc0ODE1NjAwMzJkNzM3NDlkYWY5ZDMzMmE3ODgzNTEwZTYwZWEyMjI4ODlhM2JmYzNiZWRmMzUwZjNhMzZjYWRhMzliOTQ1MzljNzRmYjgyNjU2NzhiZDVjMTQ4ZmJjOTE2OWFkY2FjZjY3MTliOTJlZThkNDJhOWQyZjg5MjNjYzRmZTNiNDk0YzQ2N2Y0ZTk4YTJhNDllMGEwZWY1YWE0MzNjYmVjNDM4YmFhMjU2YWU2MWEwNTkwY2U0ZTY3ZDBiM2ZlNWYyZGE5YWQ5MGMyNmUyMjlkMjhkNjc5NDU2OTc4ZDY1NzM1NzNlYmI0NjIzOWJhZDRhYmZhYjRmZmU2NGVhNGEzOTdjNmJjNWY3MTc1ZTFhYzM2NDg4ZjE3YzY3NzNiNWVkOTM0MTVlNTdjNDFjNmNkODg2NmRiZDEyMzYwMDYyMzM5Y2IxNTRkODVhZDFhZWNkMWQ3NjBhMDk0MWQ4MGUyOGZlMjQ2MDMzYTg2OGRiYmM4OTc1ZjM2MDQ0MzFmY2U5YWY5MWRjNDI1NDBhYjA0YjFiYmVjMjFmMzVmNzVmMzBhZjZmMDVjODk4NjQyOTM4NmUyYjQzOWJmZDJmZDU5MTJjODI2MDA4MDFlOWMwODU3ZjE2NWU4ODdmMjIzM2RjMmMwOThiYTEyNjdiMDU5ZGI4YTJkYjcxNGZlNTA2NjhkYmYwOTM2MDRhNWRmM2MyMzIxNDY3MjMyMTFjZTU4NTUyNjM4ZmFlOWZjMDY0YTdmMDliMDIwMzAxMDAwMTICGANCCgoECmCDJBC/hwNQAQ==
+    # This is a corrupted addressbook to prevent mirror importer from starting correctly
+    # The addressbook.bin file updates will be handled by infrastructure code or solo
+    addressBook: ZmFpbC1pbXBvcnRlci1zdGFydC11cAo=
     config:
       # importer is a springboot app, its application.yaml configuration starts here
       # This config is mounted at [/usr/etc/hedera/application.yaml] in the importer pod


### PR DESCRIPTION
## Description

This pull request changes the following:

- empty the mirror node importers address book value
- default the hedera-mirror-node and hedera-explorer to false so that the address book can be updated prior to launching it with a `helm upgrade`
- enhance the `uploader-mirror-secrets.yaml` to not reset the passwords upon a `helm upgrade`

### Related Issues

- Closes #761 
- required by https://github.com/hashgraph/solo/pull/52
