### PR TITLE
fix: service name has to match statefulset name for DNS to work correctly

### DIFF
--- a/charts/fullstack-deployment/config-files/envoy.yaml
+++ b/charts/fullstack-deployment/config-files/envoy.yaml
@@ -81,7 +81,7 @@ static_resources:
             - endpoint:
                 address:
                   socket_address:
-                    address: network-{{ .nodeConfig.name }}-svc
+                    address: network-{{ .nodeConfig.name }}
                     port_value: 50211
     - name: envoy-admin
       connect_timeout: 0.25s

--- a/charts/fullstack-deployment/config-files/haproxy.cfg
+++ b/charts/fullstack-deployment/config-files/haproxy.cfg
@@ -54,7 +54,7 @@ frontend http_frontend
 backend http_backend
     mode http
     http-reuse always
-    server hedera-services-node network-{{ .nodeConfig.name }}-svc:50211 proto h2 check inter 5s downinter 5s observe layer4 error-limit 5 on-error mark-down minconn 5 maxconn 1000
+    server hedera-services-node network-{{ .nodeConfig.name }}:50211 proto h2 check inter 5s downinter 5s observe layer4 error-limit 5 on-error mark-down minconn 5 maxconn 1000
     # server options: https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5.2
         # proto h2                Force HTTP/2 on clear TCP, because it is faster than HTTP/1.1
         # check                   enable health checks on the server, all below options are health check options:
@@ -86,7 +86,7 @@ backend tls_backend
     mode http
     http-reuse always
     # server server1 "${HAPROXY_TARGET_IP}":50212 alpn h2 ssl check inter 10s downinter 10s error-limit 5 on-error mark-down minconn 5 maxconn 1000
-    server hedera-services-node network-{{ .nodeConfig.name }}-svc:50212 alpn h2 ssl check inter 5s downinter 5s error-limit 5 on-error mark-down minconn 5 maxconn 1000
+    server hedera-services-node network-{{ .nodeConfig.name }}:50212 alpn h2 ssl check inter 5s downinter 5s error-limit 5 on-error mark-down minconn 5 maxconn 1000
     # server options: https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5.2
         # alpn h2             prefer HTTP/2
         # ssl                 enable TLS (we set "ssl-server-verify none" in global section above)

--- a/charts/fullstack-deployment/config-files/otel-collector-config.yaml
+++ b/charts/fullstack-deployment/config-files/otel-collector-config.yaml
@@ -18,7 +18,7 @@ processors:
 
 exporters:
   prometheus:
-    endpoint: "0.0.0.0:9090" # note: network-node-svc exposes this port for all prometheus metrics instead of node's port 9999
+    endpoint: "0.0.0.0:9090" # note: network-node service exposes this port for all prometheus metrics instead of node's port 9999
     const_labels:
       source: p-{{ default "otel-collector" .otelDefaults.nameOverride }} # PromQL: {source="p-otel-collector"}
 

--- a/charts/fullstack-deployment/templates/services/network-node-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/network-node-svc.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: network-{{ $nodeConfig.name }}-svc
+  name: network-{{ $nodeConfig.name }}
   namespace: {{ default $.Release.Namespace $.Values.global.namespaceOverride }}
   labels:
     fullstack.hedera.com/type: network-node-svc


### PR DESCRIPTION
## Description

This pull request changes the following:

- update service name to match statefulset name for DNS to work correctly

### Related Issues

- Closes #814 
- Required by [#96](https://github.com/hashgraph/solo/issues/96)
