### PR TITLE
fix: revert change to enable web3 again for mirror node

### DIFF
--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -246,8 +246,6 @@ hedera-mirror-node:
     enabled: false
   redis:
     enabled: false # not needed for default FST use case
-  web3:
-    enabled: false
   global:
     namespaceOverride: "{{ tpl (.Values.global.namespaceOverride | toString) }}"
 
@@ -347,6 +345,17 @@ hedera-mirror-node:
         effect: "NoSchedule"
     monitor:
       enabled: false
+  web3:
+    nodeSelector: {}
+    tolerations:
+      - key: "fullstack-scheduling.io/os"
+        operator: "Equal"
+        value: "linux"
+        effect: "NoSchedule"
+      - key: "fullstack-scheduling.io/role"
+        operator: "Equal"
+        value: "network"
+        effect: "NoSchedule"
 
 haproxy-ingress:
   controller:


### PR DESCRIPTION
## Description

This pull request changes the following:

- re-enable enable web3 

### Related Issues

- Closes #835 
