### PR TITLE
fix: set network node service as a headless service to support FQDN on GKE

### DIFF
--- a/charts/fullstack-deployment/templates/services/network-node-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/network-node-svc.yaml
@@ -11,6 +11,7 @@ metadata:
     fullstack.hedera.com/prometheus-endpoint: active
     {{- include "fullstack.testLabels" $ | nindent 4 }}
 spec:
+  clusterIP: None
   selector:
     app: network-{{ $nodeConfig.name }}
   ports:


### PR DESCRIPTION

## Description

This pull request changes the following:

- set network node service as a headless service to support FQDN on GKE in order for config.txt/address book to work correctly with the current solo logic.

### Related Issues

- Closes #848 
