### PR TITLE
feat: update haproxy to use startup probe and not expose and not expose service port 5555

### DIFF
--- a/.github/workflows/zxc-helm-chart-tests.yaml
+++ b/.github/workflows/zxc-helm-chart-tests.yaml
@@ -102,13 +102,6 @@ jobs:
           # the fetch depth defaults to only the commit that triggered the workflow unless the spotless check was enabled
           fetch-depth: ${{ inputs.enable-spotless-check && '0' || '' }}
 
-      - name: Docker Prune
-        id: docker-prune
-        if: ${{ steps.check-changed-files.outputs.run-tests && !cancelled() && !failure() }}
-        run: |
-          docker system prune -f
-          docker image prune -f
-
       - name: Install wget
         run: |
           sudo apt-get update

--- a/charts/fullstack-deployment/config-files/haproxy.cfg
+++ b/charts/fullstack-deployment/config-files/haproxy.cfg
@@ -33,6 +33,9 @@ program api
   command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --restart-cmd "kill -SIGUSR2 1" --userlist haproxy-dataplaneapi
   no option start-on-reload
 
+resolvers k8s_resolver
+  nameserver kubedns kube-dns.kube-system.svc.cluster.local:53
+
 frontend http_frontend
     mode http
     option logasap
@@ -52,7 +55,7 @@ frontend http_frontend
 backend http_backend
     mode http
     http-reuse always
-    server hedera-services-node network-{{ .nodeConfig.name }}:50211 proto h2 check inter 5s downinter 5s observe layer4 error-limit 5 on-error mark-down minconn 5 maxconn 1000
+    server hedera-services-node network-{{ .nodeConfig.name }}:50211 proto h2 check inter 5s downinter 5s observe layer4 error-limit 5 on-error mark-down minconn 5 maxconn 1000 init-addr none resolvers k8s_resolver
     # server options: https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5.2
         # proto h2                Force HTTP/2 on clear TCP, because it is faster than HTTP/1.1
         # check                   enable health checks on the server, all below options are health check options:
@@ -84,7 +87,7 @@ backend tls_backend
     mode http
     http-reuse always
     # server server1 "${HAPROXY_TARGET_IP}":50212 alpn h2 ssl check inter 10s downinter 10s error-limit 5 on-error mark-down minconn 5 maxconn 1000
-    server hedera-services-node network-{{ .nodeConfig.name }}:50212 alpn h2 ssl check inter 5s downinter 5s error-limit 5 on-error mark-down minconn 5 maxconn 1000
+    server hedera-services-node network-{{ .nodeConfig.name }}:50212 alpn h2 ssl check inter 5s downinter 5s error-limit 5 on-error mark-down minconn 5 maxconn 1000 init-addr none resolvers k8s_resolver
     # server options: https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5.2
         # alpn h2             prefer HTTP/2
         # ssl                 enable TLS (we set "ssl-server-verify none" in global section above)

--- a/charts/fullstack-deployment/config-files/haproxy.cfg
+++ b/charts/fullstack-deployment/config-files/haproxy.cfg
@@ -34,7 +34,14 @@ program api
   no option start-on-reload
 
 resolvers k8s_resolver
-  nameserver kubedns kube-dns.kube-system.svc.cluster.local:53
+  parse-resolv-conf
+  hold valid    10s
+  # How many times to retry a query
+  resolve_retries 3
+  # How long to wait between retries when no valid response has been received
+  timeout retry 1s
+  # How long to wait for a successful resolution
+  timeout resolve 1s
 
 frontend http_frontend
     mode http
@@ -55,7 +62,7 @@ frontend http_frontend
 backend http_backend
     mode http
     http-reuse always
-    server hedera-services-node network-{{ .nodeConfig.name }}:50211 proto h2 check inter 5s downinter 5s observe layer4 error-limit 5 on-error mark-down minconn 5 maxconn 1000 init-addr none resolvers k8s_resolver
+    server hedera-services-node network-{{ .nodeConfig.name }}.{{ .namespace }}.svc.cluster.local:50211 proto h2 check inter 5s downinter 5s observe layer4 error-limit 5 on-error mark-down minconn 5 maxconn 1000 init-addr libc,none resolvers k8s_resolver
     # server options: https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5.2
         # proto h2                Force HTTP/2 on clear TCP, because it is faster than HTTP/1.1
         # check                   enable health checks on the server, all below options are health check options:
@@ -87,7 +94,7 @@ backend tls_backend
     mode http
     http-reuse always
     # server server1 "${HAPROXY_TARGET_IP}":50212 alpn h2 ssl check inter 10s downinter 10s error-limit 5 on-error mark-down minconn 5 maxconn 1000
-    server hedera-services-node network-{{ .nodeConfig.name }}:50212 alpn h2 ssl check inter 5s downinter 5s error-limit 5 on-error mark-down minconn 5 maxconn 1000 init-addr none resolvers k8s_resolver
+    server hedera-services-node network-{{ .nodeConfig.name }}.{{ .namespace }}.svc.cluster.local:50212 alpn h2 ssl check inter 5s downinter 5s error-limit 5 on-error mark-down minconn 5 maxconn 1000 init-addr libc,none resolvers k8s_resolver
     # server options: https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#5.2
         # alpn h2             prefer HTTP/2
         # ssl                 enable TLS (we set "ssl-server-verify none" in global section above)

--- a/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
+++ b/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
@@ -10,7 +10,7 @@ metadata:
     {{- include "fullstack.testLabels" $ | nindent 4 }}
 data:
   haproxy.cfg: |
-    {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "Template" $.Template) | nindent 4 }}
+    {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "namespace" $.Release.Namespace "Template" $.Template) | nindent 4 }}
 ---
 {{ end }}
 apiVersion: v1

--- a/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
@@ -49,6 +49,32 @@ spec:
       - name: {{ default $defaults.nameOverride $haproxy.nameOverride }}
         image: {{ include "fullstack.container.image" (dict "image" $haproxy.image "Chart" $.Chart "defaults" $defaults ) }}
         imagePullPolicy: {{ include "fullstack.images.pullPolicy" (dict "image" $haproxy.image "defaults" $defaults )  }}
+        startupProbe:
+          exec:
+            command:
+            - "/bin/sh"
+            - "-c"
+            - |
+              jq_check() {
+                jq --version > /dev/null 2>&1 && return
+                echo "jq not found, installing jq"
+                apk update -q && apk add jq || return 1
+              }
+              probe() {
+                jq_check || return 1
+                wget -q -O response.json --header "Authorization: Basic $(echo -n "admin:adminpwd" | base64)" http://localhost:5555/v2/services/haproxy/stats/native?type=backend || return 1
+                BACKEND_STATUS=$(jq '.[] | .stats[] | select(.name == "http_backend") | .stats.status' < response.json)
+                echo "http_backend status: $BACKEND_STATUS"
+                if [ $BACKEND_STATUS = "UP" ]; then
+                  return 0
+                else
+                  return 1
+                fi
+              }
+              probe
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          failureThreshold: 720
         volumeMounts:
           - name: haproxy-config-volume
             # https://hub.docker.com/_/haproxy/
@@ -63,8 +89,6 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        ports:
-          - containerPort: 5555 # data plane api
 {{- end }}
 {{- end }}
 

--- a/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
@@ -63,9 +63,9 @@ spec:
               probe() {
                 jq_check || return 1
                 wget -q -O response.json --header "Authorization: Basic $(echo -n "admin:adminpwd" | base64)" http://localhost:5555/v2/services/haproxy/stats/native?type=backend || return 1
-                BACKEND_STATUS=$(jq '.[] | .stats[] | select(.name == "http_backend") | .stats.status' < response.json)
+                BACKEND_STATUS=$(jq -r '.[] | .stats[] | select(.name == "http_backend") | .stats.status' < response.json)
                 echo "http_backend status: $BACKEND_STATUS"
-                if [ $BACKEND_STATUS = "UP" ]; then
+                if [ "$BACKEND_STATUS" = "UP" ]; then
                   return 0
                 else
                   return 1

--- a/charts/fullstack-deployment/templates/services/haproxy-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/haproxy-svc.yaml
@@ -28,9 +28,6 @@ spec:
     - name: prometheus # port name must be prometheus for prometheus-svc-monitor
       port: 9090
       targetPort: 9090 # stats port
-    - name: data-plane-api
-      port: 5555
-      targetPort: 5555
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Description

This pull request changes the following:

- update haproxy to use startup probe and not expose and not expose service port 5555
- remove docker prune from `.github/workflows/zxc-helm-chart-tests.yaml`
- update `charts/fullstack-deployment/config-files/haproxy.cfg` to not fail when network-nodeX DNS is not resolvable because it is still starting

### Related Issues

- Closes #852 
