### PR TITLE
fix: update chart services to use a local external traffic policy

### DIFF
--- a/charts/fullstack-deployment/templates/services/envoy-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/envoy-svc.yaml
@@ -18,6 +18,7 @@ spec:
   {{- if $envoyProxy.loadBalancerEnabled }}
   type: LoadBalancer
   {{- end }}
+  externalTrafficPolicy: Local
   selector:
     app: envoy-proxy-{{ $node.name }}
   ports:

--- a/charts/fullstack-deployment/templates/services/haproxy-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/haproxy-svc.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- include "fullstack.testLabels" $ | nindent 4 }}
 spec:
   type: {{ $defaults.serviceType | default "ClusterIP" }}
+  externalTrafficPolicy: Local
   selector:
     app: haproxy-{{ $node.name }}
   ports:

--- a/charts/fullstack-deployment/templates/services/network-node-svc.yaml
+++ b/charts/fullstack-deployment/templates/services/network-node-svc.yaml
@@ -21,6 +21,7 @@ spec:
   type: {{ $defaults.serviceType | default "ClusterIP" }}
   {{- end }}
   publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
   selector:
     app: network-{{ $nodeConfig.name }}
   ports:


### PR DESCRIPTION
## Description

This pull request changes the following:

- Updates service definitions for the network nodes, envoy and haproxy pods.

### Related Issues

- Closes #874 
