### PR TITLE
fix: add support for extraEnv specification on network node root containers

### DIFF
--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -2,6 +2,7 @@
 {{- $hapiAppSecrets := lookup "v1" "Secret" $.Release.Namespace "network-node-hapi-app-secrets" }}
 {{- $networkNodeKeySecrets := lookup "v1" "Secret" $.Release.Namespace "network-node-keys-secrets" }}
 {{- $root := $node.root | default $.Values.defaults.root -}}
+{{- $rootExtraEnv := ($root).extraEnv | default $.Values.defaults.root.extraEnv -}}
 {{- $rootImage := ($node.root).image | default $.Values.defaults.root.image -}}
 {{- $recordStream := ($node.sidecars).recordStreamUploader | default $.Values.defaults.sidecars.recordStreamUploader -}}
 {{- $eventStream := ($node.sidecars).eventStreamUploader | default $.Values.defaults.sidecars.eventStreamUploader -}}
@@ -229,6 +230,9 @@ spec:
             mountPath: /opt/hgcapp/services-hedera/HapiApp2.0/output
         env:
           {{- include "fullstack.defaultEnvVars" . | nindent 10 }}
+          {{- with $rootExtraEnv }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- if $balanceUploader.enabled }}
       # Sidecar: {{ $node.name }}-account-balance-uploader
       - name: {{ default "account-balance-uploader" $balanceUploader.nameOverride }}

--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -66,10 +66,11 @@ defaults:
   root: # root container
     image:
       registry: "ghcr.io"
-      repository: "hashgraph/full-stack-testing/ubi8-init-java17"
+      repository: "hashgraph/full-stack-testing/ubi8-init-java21"
       tag: "" # this should be empty since we want the default behavior of $.Chart.appVersion to apply
       pullPolicy: "IfNotPresent"
     resources: {}
+    extraEnv: []
   service:
     serviceType: "LoadBalancer"
   haproxy:


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for the specification of `extraEnv` on a per node basis on the network node root container. 

### Related Issues

- Closes #884 
