### PR TITLE
fix: allow entry point supported environment variables to be passed via systemd

### DIFF
--- a/docker/ubi8-init-java21/network-node.service
+++ b/docker/ubi8-init-java21/network-node.service
@@ -8,7 +8,7 @@ Restart=no
 User=hedera
 Group=hedera
 
-PassEnvironment=JAVA_HOME JAVA_OPTS JAVA_HEAP_MIN JAVA_HEAP_MAX PATH APP_HOME
+PassEnvironment=JAVA_HOME JAVA_OPTS JAVA_HEAP_MIN JAVA_HEAP_MAX JAVA_MAIN_CLASS JAVA_CLASS_PATH PATH APP_HOME
 EnvironmentFile=/etc/network-node/application.env
 
 WorkingDirectory=/opt/hgcapp/services-hedera/HapiApp2.0


### PR DESCRIPTION
## Description

This pull request changes the following:

- Allows the `JAVA_MAIN_CLASS` and `JAVA_CLASS_PATH` environment variables to be passed to `entrypoint.sh` script when started via systemd.

### Related Issues

- Closes #888
