### PR TITLE
ci: create random user name and password for haproxy

### DIFF
--- a/charts/fullstack-deployment/config-files/haproxy.cfg
+++ b/charts/fullstack-deployment/config-files/haproxy.cfg
@@ -26,11 +26,11 @@ defaults
     timeout http-keep-alive 30s
     option http-keep-alive
 
-userlist haproxy-dataplaneapi
-  user admin insecure-password adminpwd
+userlist {{ .haproxy_user }}
+  user admin insecure-password {{ .haproxy_password }}
 
 program api
-  command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --restart-cmd "kill -SIGUSR2 1" --userlist haproxy-dataplaneapi
+  command /usr/bin/dataplaneapi --host 0.0.0.0 --port 5555 --haproxy-bin /usr/sbin/haproxy --config-file /usr/local/etc/haproxy/haproxy.cfg --reload-cmd "kill -SIGUSR2 1" --reload-delay 5 --restart-cmd "kill -SIGUSR2 1" --userlist {{ .haproxy_user }}
   no option start-on-reload
 
 resolvers k8s_resolver

--- a/charts/fullstack-deployment/templates/_helpers.tpl
+++ b/charts/fullstack-deployment/templates/_helpers.tpl
@@ -74,3 +74,23 @@ export MINIO_ROOT_PASSWORD={{ include "minio.secretKey" . }}
   emptyDir: {}
   {{- end }}
 {{- end -}}
+
+{{- define "generateHaproxyPassword" -}}
+{{- $password := randAlpha 10 -}}
+{{- $previous := lookup "v1" "Secret" .Release.Namespace "haproxy-secrets" }}
+{{- if and $previous (index $previous.data "haproxy_password") -}}
+{{- $password := $previous.data.haproxy_password -}}
+{{- end -}}
+{{- $_ := set .Values.global "haproxy_password" ($password) -}}
+{{- $password -}}
+{{- end -}}
+
+{{- define "generateHaproxyUser" -}}
+{{- $username := randAlpha 10 -}}
+{{- $previous := lookup "v1" "Secret" .Release.Namespace "haproxy-secrets" }}
+{{- if and $previous (index $previous.data "haproxy_user") -}}
+{{- $username := $previous.data.haproxy_user -}}
+{{- end -}}
+{{- $_ := set .Values.global "haproxy_user" ($username) -}}
+{{- $username -}}
+{{- end -}}

--- a/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
+++ b/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
@@ -1,6 +1,8 @@
 # Create a haproxy configmap for each network node
 # This will change in the future, we plan create a haproxy for a given network node only if specified in the config
 {{- range $index, $node := ($.Values.hedera.nodes) }}
+{{- $random_user := randAlpha 10  -}}
+{{- $random_password := randAlpha 10  -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,6 +13,7 @@ metadata:
 data:
   haproxy.cfg: |
     {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "namespace" $.Release.Namespace "Template" $.Template) | nindent 4 }}
+    {{ (dict "haproxy_user" $random_user "haproxy_password" $random_password) }}
 ---
 {{ end }}
 apiVersion: v1

--- a/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
+++ b/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
@@ -1,4 +1,3 @@
-{{- $previous := lookup "v1" "ConfigMap" .Release.Namespace "haproxy-cm-{{ $node.name }}" }}
 # Create a haproxy configmap for each network node
 # This will change in the future, we plan create a haproxy for a given network node only if specified in the config
 {{- $haproxy_password := .Values.global.haproxy_password  -}}

--- a/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
+++ b/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
@@ -1,8 +1,9 @@
+{{- $previous := lookup "v1" "ConfigMap" .Release.Namespace "haproxy-cm-{{ $node.name }}" }}
 # Create a haproxy configmap for each network node
 # This will change in the future, we plan create a haproxy for a given network node only if specified in the config
-{{- range $index, $node := ($.Values.hedera.nodes) }}
 {{- $random_user := randAlpha 10  -}}
 {{- $random_password := randAlpha 10  -}}
+{{- range $index, $node := ($.Values.hedera.nodes) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,8 +13,7 @@ metadata:
     {{- include "fullstack.testLabels" $ | nindent 4 }}
 data:
   haproxy.cfg: |
-    {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "namespace" $.Release.Namespace "Template" $.Template) | nindent 4 }}
-    {{ (dict "haproxy_user" $random_user "haproxy_password" $random_password) }}
+    {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "namespace" $.Release.Namespace "haproxy_user" $random_user "haproxy_password" $random_password "Template" $.Template) | nindent 4 }}
 ---
 {{ end }}
 apiVersion: v1

--- a/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
+++ b/charts/fullstack-deployment/templates/configmaps/haproxy-cm.yaml
@@ -1,8 +1,8 @@
 {{- $previous := lookup "v1" "ConfigMap" .Release.Namespace "haproxy-cm-{{ $node.name }}" }}
 # Create a haproxy configmap for each network node
 # This will change in the future, we plan create a haproxy for a given network node only if specified in the config
-{{- $random_user := randAlpha 10  -}}
-{{- $random_password := randAlpha 10  -}}
+{{- $haproxy_password := .Values.global.haproxy_password  -}}
+{{- $haproxy_user := .Values.global.haproxy_user  -}}
 {{- range $index, $node := ($.Values.hedera.nodes) }}
 apiVersion: v1
 kind: ConfigMap
@@ -13,7 +13,7 @@ metadata:
     {{- include "fullstack.testLabels" $ | nindent 4 }}
 data:
   haproxy.cfg: |
-    {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "namespace" $.Release.Namespace "haproxy_user" $random_user "haproxy_password" $random_password "Template" $.Template) | nindent 4 }}
+    {{- tpl ($.Files.Get "config-files/haproxy.cfg") (dict "nodeConfig" $node "namespace" $.Release.Namespace "haproxy_user" $haproxy_user "haproxy_password" $haproxy_password "Template" $.Template) | nindent 4 }}
 ---
 {{ end }}
 apiVersion: v1

--- a/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
@@ -53,13 +53,10 @@ spec:
           httpGet:
             path: /v2/services/haproxy/stats/native?type=backend
             port: 5555
-          initialDelaySeconds: 30
-          periodSeconds: 10
         readinessProbe:
-          tcpSocket:
+          httpGet:
+            path: /v2/services/haproxy/stats/native?type=backend
             port: 5555
-          initialDelaySeconds: 30
-          periodSeconds: 10
         startupProbe:
           exec:
             command:
@@ -73,7 +70,7 @@ spec:
               }
               probe() {
                 jq_check || return 1
-                wget -q -O response.json --header "Authorization: Basic $(echo -n "admin:adminpwd" | base64)" http://localhost:5555/v2/services/haproxy/stats/native?type=backend || return 1
+                wget -q -O response.json --header "Authorization: Basic $(echo -n "admin:{{ $.Values.global.haproxy_password }}" | base64)" http://localhost:5555/v2/services/haproxy/stats/native?type=backend || return 1
                 BACKEND_STATUS=$(jq -r '.[] | .stats[] | select(.name == "http_backend") | .stats.status' < response.json)
                 echo "http_backend status: $BACKEND_STATUS"
                 if [ "$BACKEND_STATUS" = "UP" ]; then

--- a/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
@@ -49,6 +49,17 @@ spec:
       - name: {{ default $defaults.nameOverride $haproxy.nameOverride }}
         image: {{ include "fullstack.container.image" (dict "image" $haproxy.image "Chart" $.Chart "defaults" $defaults ) }}
         imagePullPolicy: {{ include "fullstack.images.pullPolicy" (dict "image" $haproxy.image "defaults" $defaults )  }}
+        livenessProbe:
+          httpGet:
+            path: /v2/services/haproxy/stats/native?type=backend
+            port: 5555
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: 5555
+          initialDelaySeconds: 30
+          periodSeconds: 10
         startupProbe:
           exec:
             command:

--- a/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
+++ b/charts/fullstack-deployment/templates/proxy/haproxy-deployment.yaml
@@ -70,7 +70,7 @@ spec:
               }
               probe() {
                 jq_check || return 1
-                wget -q -O response.json --header "Authorization: Basic $(echo -n "admin:{{ $.Values.global.haproxy_password }}" | base64)" http://localhost:5555/v2/services/haproxy/stats/native?type=backend || return 1
+                wget -q -O response.json --header "Authorization: Basic $(echo -n "admin:{{ $.Values.global.haproxy_password }}")" http://localhost:5555/v2/services/haproxy/stats/native?type=backend || return 1
                 BACKEND_STATUS=$(jq -r '.[] | .stats[] | select(.name == "http_backend") | .stats.status' < response.json)
                 echo "http_backend status: $BACKEND_STATUS"
                 if [ "$BACKEND_STATUS" = "UP" ]; then

--- a/charts/fullstack-deployment/templates/secrets/haproxy-secrets.yaml
+++ b/charts/fullstack-deployment/templates/secrets/haproxy-secrets.yaml
@@ -1,4 +1,3 @@
-{{- $previous := lookup "v1" "Secret" .Release.Namespace "haproxy-secrets" }}
 {{- $password := include "generateHaproxyPassword" . -}}
 {{- $username := include "generateHaproxyUser" . -}}
 apiVersion: v1

--- a/charts/fullstack-deployment/templates/secrets/haproxy-secrets.yaml
+++ b/charts/fullstack-deployment/templates/secrets/haproxy-secrets.yaml
@@ -1,0 +1,12 @@
+{{- $previous := lookup "v1" "Secret" .Release.Namespace "haproxy-secrets" }}
+{{- $password := include "generateHaproxyPassword" . -}}
+{{- $username := include "generateHaproxyUser" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: haproxy-secrets
+type: Opaque
+data:
+  haproxy_user: {{ $username }}
+  haproxy_password: {{ $password }}
+---

--- a/charts/fullstack-deployment/templates/secrets/haproxy-secrets.yaml
+++ b/charts/fullstack-deployment/templates/secrets/haproxy-secrets.yaml
@@ -5,7 +5,7 @@ kind: Secret
 metadata:
   name: haproxy-secrets
 type: Opaque
-data:
+stringData:
   haproxy_user: {{ $username }}
   haproxy_password: {{ $password }}
 ---


### PR DESCRIPTION
## Description

This pull request changes the following:

- Created template function to create random proxy user name and password if do not exist
- Use haproxy user name and password as global values so they can be used in both `haproxy-cm.yaml` and `haproxy-deployment.yaml`

### Related Issues

- Closes #854 
