### PR TITLE
ci: increase mirror chart version

### DIFF
--- a/charts/fullstack-deployment/Chart.lock
+++ b/charts/fullstack-deployment/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.2.0
 - name: hedera-mirror
   repository: https://hashgraph.github.io/hedera-mirror-node/charts
-  version: 0.107.2
+  version: 0.109.0
 - name: tenant
   repository: https://operator.min.io/
   version: 5.0.12

--- a/charts/fullstack-deployment/Chart.yaml
+++ b/charts/fullstack-deployment/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   # hedera-mirror-node
   - name: hedera-mirror
     alias: hedera-mirror-node
-    version: 0.107.2
+    version: 0.109.0
     repository: https://hashgraph.github.io/hedera-mirror-node/charts
     condition: hedera-mirror-node.enabled
 

--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -372,6 +372,8 @@ hedera-mirror-node:
         effect: "NoSchedule"
     monitor:
       enabled: false
+    redis:
+      enabled: true
   web3:
     nodeSelector: {}
     tolerations:

--- a/charts/fullstack-deployment/values.yaml
+++ b/charts/fullstack-deployment/values.yaml
@@ -270,7 +270,7 @@ hedera-mirror-node:
   rosetta: # not needed for default FST use case
     enabled: false
   redis:
-    enabled: false # not needed for default FST use case
+    enabled: true
   global:
     namespaceOverride: "{{ tpl (.Values.global.namespaceOverride | toString) }}"
 


### PR DESCRIPTION
## Description

This pull request changes the following:

- Increase mirror node version number
- Enable redis container since it is needed for importer

### Related Issues

- Closes #939 
