### PR TITLE
chore: migrate helm-gh-pages to step-security maintained version

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -201,7 +201,7 @@ jobs:
           arguments: versionAsSpecified --scan -PnewVersion=${{ needs.prepare-release.outputs.version }}
 
       - name: Publish Helm Charts
-        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 #v1.7.0
+        uses: step-security/helm-gh-pages@6a390e89293c1ec8bc5120f6692f3b8a313a9a3d #v1.7.0
         if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

 This PR migrates the `helm-gh-pages` action to the step-security maintained version

### Related Issues

- Closes #929 
