### PR TITLE
fix: bump mirror node in FST helm chart to 0.111.1

### DIFF
--- a/charts/fullstack-deployment/Chart.yaml
+++ b/charts/fullstack-deployment/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
   # hedera-mirror-node
   - name: hedera-mirror
     alias: hedera-mirror-node
-    version: 0.110.1
+    version: 0.111.1
     repository: https://hashgraph.github.io/hedera-mirror-node/charts
     condition: hedera-mirror-node.enabled
 


### PR DESCRIPTION
## Description

This pull request changes the following:

- bump mirror node in FST helm chart to 0.111.1

### Related Issues

- required by https://github.com/hashgraph/solo/pull/518
