### PR TITLE
feat(helm): add liveness probe to node

### DIFF
--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -156,12 +156,25 @@ spec:
                 task() {
                   mkdir -p /opt/hgcapp/recordStreams/record{{ $node.accountId }}/sidecar
                   chmod 777 /opt/hgcapp/recordStreams/record{{ $node.accountId }}/sidecar
-                  curl network-{{ $node.name }}-0.network-{{ $node.name }}.{{ default $.Release.Namespace $.Values.global.namespaceOverride }}.svc.cluster.local:13133                
+                  curl network-{{ $node.name }}-0.network-{{ $node.name }}.{{ default $.Release.Namespace $.Values.global.namespaceOverride }}.svc.cluster.local:13133
                 }
                 task
           failureThreshold: 30
           periodSeconds: 10
           timeoutSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 9090
+            scheme: HTTP
+            httpHeaders:
+              - name: Accept
+                value: application/json
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
         image: {{ include "fullstack.container.image" (dict "image" $rootImage "Chart" $.Chart "defaults" $.Values.defaults) }}
         imagePullPolicy: {{ include "fullstack.images.pullPolicy" (dict "image" $rootImage "defaults" $.Values.defaults) }}
         securityContext: # need to run as root with privileged mode


### PR DESCRIPTION
## Description

added simple 'httpGet' liveness probe to network node statefulset that hits the prometheus metrics endpoint to determine liveliness for the node

### Related Issues

- Required by:
https://github.com/hashgraph/solo/issues/209
