### PR TITLE
fix: reverts network node liveness probe hitting prometheus metrics endpoint

### DIFF
--- a/charts/fullstack-deployment/templates/network-node-statefulset.yaml
+++ b/charts/fullstack-deployment/templates/network-node-statefulset.yaml
@@ -156,25 +156,12 @@ spec:
                 task() {
                   mkdir -p /opt/hgcapp/recordStreams/record{{ $node.accountId }}/sidecar
                   chmod 777 /opt/hgcapp/recordStreams/record{{ $node.accountId }}/sidecar
-                  curl network-{{ $node.name }}-0.network-{{ $node.name }}.{{ default $.Release.Namespace $.Values.global.namespaceOverride }}.svc.cluster.local:13133
+                  curl network-{{ $node.name }}-0.network-{{ $node.name }}.{{ default $.Release.Namespace $.Values.global.namespaceOverride }}.svc.cluster.local:13133                
                 }
                 task
           failureThreshold: 30
           periodSeconds: 10
           timeoutSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /metrics
-            port: 9090
-            scheme: HTTP
-            httpHeaders:
-              - name: Accept
-                value: application/json
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 3
-          successThreshold: 1
         image: {{ include "fullstack.container.image" (dict "image" $rootImage "Chart" $.Chart "defaults" $.Values.defaults) }}
         imagePullPolicy: {{ include "fullstack.images.pullPolicy" (dict "image" $rootImage "defaults" $.Values.defaults) }}
         securityContext: # need to run as root with privileged mode


### PR DESCRIPTION
This reverts commit bf1f9c1ef6a58f1d3ec1719b022a15408b65db0f.

## Description

This pull request changes the following:

- reverts https://github.com/hashgraph/full-stack-testing/issues/818, this will not work the way we planned. We now intend to hit the prometheus metrics endpoint directly on the Solo side.

### Related Issues

- Closes #966
